### PR TITLE
Add flow control support on client and server.

### DIFF
--- a/java-runtime/src/main/scala/client/Fs2ClientCall.scala
+++ b/java-runtime/src/main/scala/client/Fs2ClientCall.scala
@@ -34,7 +34,7 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (val call: ClientCa
   private def request(numMessages: Int)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.request(numMessages))
 
-  private def sendMessage(message: Request)(implicit F: Concurrent[F]): F[Unit] = {
+  private def sendMessage(message: Request)(implicit F: Sync[F]): F[Unit] = {
     F.delay(call.sendMessage(message))
   }
 
@@ -57,7 +57,7 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (val call: ClientCa
     createListener.flatTap(start(_, headers)) <* request(1)
   }
 
-  def sendSingleMessage(message: Request)(implicit F: Concurrent[F]): F[Unit] = {
+  def sendSingleMessage(message: Request)(implicit F: Sync[F]): F[Unit] = {
     sendMessage(message) *> halfClose
   }
 

--- a/java-runtime/src/main/scala/server/Fs2ServerCall.scala
+++ b/java-runtime/src/main/scala/server/Fs2ServerCall.scala
@@ -3,10 +3,25 @@ package java_runtime
 package server
 
 import cats.effect._
+import cats.effect.concurrent.{Deferred, Ref}
+import cats.implicits._
 import io.grpc._
 
 // TODO: Add attributes, compression, message compression.
-private[server] class Fs2ServerCall[F[_], Request, Response](val call: ServerCall[Request, Response]) extends AnyVal {
+private[server] class Fs2ServerCall[F[_], Request, Response](val call: ServerCall[Request, Response],
+                                                             val wakeOnReady: Ref[F, Option[Deferred[F, Unit]]]) {
+  def onReady()(implicit F: Sync[F]): F[Unit] = {
+    wakeOnReady
+      .modify({
+        case None       => (None, F.unit)
+        case Some(wake) => (None, wake.complete(()))
+      })
+      .flatten
+  }
+
+  def isReady(implicit F: Sync[F]): F[Boolean] =
+    F.delay(call.isReady)
+
   def sendHeaders(headers: Metadata)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.sendHeaders(headers))
 
@@ -16,11 +31,24 @@ private[server] class Fs2ServerCall[F[_], Request, Response](val call: ServerCal
   def sendMessage(message: Response)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.sendMessage(message))
 
+  def sendMessageOrDelay(message: Response)(implicit F: Concurrent[F]): F[Unit] =
+    isReady.ifM(
+      sendMessage(message), {
+        Deferred[F, Unit].flatMap { wakeup =>
+          wakeOnReady.set(wakeup.some) *>
+            isReady.ifM(sendMessage(message), wakeup.get *> sendMessage(message))
+        }
+      }
+    )
+
   def request(numMessages: Int)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.request(numMessages))
 }
 
 private[server] object Fs2ServerCall {
-  def apply[F[_], Request, Response](call: ServerCall[Request, Response]): Fs2ServerCall[F, Request, Response] =
-    new Fs2ServerCall[F, Request, Response](call)
+  def apply[F[_], Request, Response](call: ServerCall[Request, Response])(
+      implicit F: Concurrent[F]): F[Fs2ServerCall[F, Request, Response]] =
+    for {
+      wakeOnReady <- Ref[F].of(none[Deferred[F, Unit]])
+    } yield new Fs2ServerCall[F, Request, Response](call, wakeOnReady)
 }

--- a/java-runtime/src/main/scala/server/Fs2UnaryServerCallListener.scala
+++ b/java-runtime/src/main/scala/server/Fs2UnaryServerCallListener.scala
@@ -17,6 +17,10 @@ class Fs2UnaryServerCallListener[F[_], Request, Response] private (
 
   import Fs2UnaryServerCallListener._
 
+  override def onReady(): Unit = {
+    call.onReady().unsafeRun()
+  }
+
   override def onCancel(): Unit = {
     isCancelled.complete(()).unsafeRun()
   }
@@ -62,11 +66,8 @@ object Fs2UnaryServerCallListener {
         request     <- Ref.of[F, Option[Request]](none)
         isComplete  <- Deferred[F, Unit]
         isCancelled <- Deferred[F, Unit]
-      } yield
-        new Fs2UnaryServerCallListener[F, Request, Response](request,
-                                                             isComplete,
-                                                             isCancelled,
-                                                             Fs2ServerCall[F, Request, Response](call))
+        serverCall  <- Fs2ServerCall[F, Request, Response](call)
+      } yield new Fs2UnaryServerCallListener[F, Request, Response](request, isComplete, isCancelled, serverCall)
   }
 
   def apply[F[_]] = new PartialFs2UnaryServerCallListener[F]

--- a/java-runtime/src/test/scala/client/ClientSuite.scala
+++ b/java-runtime/src/test/scala/client/ClientSuite.scala
@@ -20,7 +20,7 @@ object ClientSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result = client.unaryToUnaryCall("hello", new Metadata()).unsafeToFuture()
     dummy.listener.get.onMessage(5)
 
@@ -44,7 +44,7 @@ object ClientSuite extends SimpleTestSuite {
     implicit val timer: Timer[IO]     = ec.timer
 
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result = client.unaryToUnaryCall("hello", new Metadata()).timeout(1.second).unsafeToFuture()
 
     ec.tick()
@@ -68,7 +68,7 @@ object ClientSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result = client.unaryToUnaryCall("hello", new Metadata()).unsafeToFuture()
 
     dummy.listener.get.onClose(Status.OK, new Metadata())
@@ -87,9 +87,8 @@ object ClientSuite extends SimpleTestSuite {
     implicit val ec: TestContext      = TestContext()
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
-
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result = client.unaryToUnaryCall("hello", new Metadata()).unsafeToFuture()
     dummy.listener.get.onMessage(5)
 
@@ -113,9 +112,8 @@ object ClientSuite extends SimpleTestSuite {
     implicit val ec: TestContext      = TestContext()
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
-
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result = client
       .streamingToUnaryCall(Stream.emits(List("a", "b", "c")), new Metadata())
       .unsafeToFuture()
@@ -140,9 +138,8 @@ object ClientSuite extends SimpleTestSuite {
     implicit val ec: TestContext      = TestContext()
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
-
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result = client
       .streamingToUnaryCall(Stream.empty, new Metadata())
       .unsafeToFuture()
@@ -168,7 +165,7 @@ object ClientSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result = client.unaryToStreamingCall("hello", new Metadata()).compile.toList.unsafeToFuture()
 
     dummy.listener.get.onMessage(1)
@@ -194,7 +191,7 @@ object ClientSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result =
       client
         .streamingToStreamingCall(Stream.emits(List("a", "b", "c", "d", "e")), new Metadata())
@@ -225,7 +222,7 @@ object ClientSuite extends SimpleTestSuite {
     implicit val timer: Timer[IO]     = ec.timer
 
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result =
       client
         .streamingToStreamingCall(Stream.emits(List("a", "b", "c", "d", "e")), new Metadata())
@@ -255,7 +252,7 @@ object ClientSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy  = new DummyClientCall()
-    val client = new Fs2ClientCall[IO, String, Int](dummy)
+    val client = Fs2ClientCall[IO](dummy).unsafeRunSync()
     val result =
       client
         .streamingToStreamingCall(Stream.emits(List("a", "b", "c", "d", "e")), new Metadata())
@@ -287,7 +284,7 @@ object ClientSuite extends SimpleTestSuite {
   }
 
   test("resource awaits termination of managed channel") {
-    implicit val ec: TestContext  = TestContext()
+    implicit val ec: TestContext = TestContext()
 
     import implicits._
     val result = ManagedChannelBuilder.forAddress("127.0.0.1", 0).resource[IO].use(IO.pure).unsafeToFuture()


### PR DESCRIPTION
In order to support gRPC's flow control, the service has to handle
`call.isReady` and the `onReady` callback. When `isReady` is false,
the code should wait for `onReady` to be true. To avoid race conditions
where we may miss a wakeup, the `isReady` condition is checked twice;
once before, and once after assigning the wakeup `Deferred` value.

Fixes #38 