### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when discussing the project on the available communication channels.
+
+## Moderation
+
+Any questions, concerns, or moderation requests please contact a member of the project.
+
+- Ross A. Baker [gitter](https://gitter.im/rossabaker) | [twitter](https://twitter.com/rossabaker) | [email](mailto:ross@rossabaker.com)
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html


### PR DESCRIPTION
To use some RFC verbs, all projects SHOULD have one, all Typelevel projects MUST.

If anyone else involved with the project volunteers to be a moderator, please add yourself.