### PR TITLE
Build codegen for all crossbuilds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,9 @@ inThisBuild(
     baseVersion := "1.0",
     versionIntroduced := Map(
       // First version under org.typelevel
-      "2.12" -> "1.1.0",
-      "2.13" -> "1.1.0",
-      "3.0.0-RC2" -> "1.1.0",
+      "2.12" -> "1.1.2",
+      "2.13" -> "1.1.2",
+      "3.0.0-RC2" -> "1.1.2",
     ),
     startYear := Some(2018),
     licenses := Seq(("MIT", url("https://github.com/typelevel/fs2-grpc/blob/master/LICENSE"))),
@@ -58,8 +58,6 @@ lazy val root = project
 lazy val codegen = project
   .settings(
     name := "fs2-grpc-codegen",
-    scalaVersion := Scala212,
-    crossScalaVersions := List(Scala212),
     libraryDependencies += scalaPbCompiler
   )
 


### PR DESCRIPTION
The codegen project is not detecting `mimaPreviousArtifacts` the way anything else is.  If we cross build it like everything else, it appears to work.  And there's really no reason that we can't, even if it is primarily used in today in the SBT plugin.