### PR TITLE
Fix MiMa check so we can publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Run tests
-        run: sbt ++${{ matrix.scala }} scalafmtCheckAll test
+        run: sbt ++${{ matrix.scala }} scalafmtCheckAll test mimaReportBinaryIssues
 
       - name: Compress target directories
         run: tar cf targets.tar plugin/target target codegen/target .protoc-gen/target runtime/target project/target

--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,9 @@ inThisBuild(
     baseVersion := "1.0",
     versionIntroduced := Map(
       // First version under org.typelevel
-      "2.12" -> "1.1.0",
-      "2.13" -> "1.1.0",
-      "3.0.0-RC2" -> "1.1.0"
+      "2.12" -> "1.1.2",
+      "2.13" -> "1.1.2",
+      "3.0.0-RC2" -> "1.1.2"
     ),
     startYear := Some(2018),
     licenses := Seq(("MIT", url("https://github.com/typelevel/fs2-grpc/blob/master/LICENSE"))),
@@ -40,7 +40,7 @@ inThisBuild(
     githubWorkflowBuild := Seq(
       WorkflowStep.Sbt(
         name = Some("Run tests"),
-        commands = List("scalafmtCheckAll", "test")
+        commands = List("scalafmtCheckAll", "test", "mimaReportBinaryIssues")
       )
     ),
     githubWorkflowTargetBranches := List("*", "series/*")


### PR DESCRIPTION
1. Add the check to tests, so we catch it before we burn tags
2. Bump the initial versions since the last two tags failed

I think this one will work, because we're not retagging a commit.  See https://github.com/djspiewak/sbt-spiewak/issues/50 for that tale of woe.