### PR TITLE
runtime: stream client call listener back-pressure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.core.ProblemFilters._
 import Dependencies._
 
 lazy val Scala3 = "3.0.0-RC2"
@@ -47,6 +49,14 @@ inThisBuild(
   ) ++ List(
     spiewakCiReleaseSnapshots := false,
     spiewakMainBranches := Seq("master", "series/0.x")
+  ) ++ List(
+    mimaBinaryIssueFilters ++= {
+      Seq(
+        // Made internal
+        exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2UnaryClientCallListener.apply"),
+        exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2StreamClientCallListener.apply")
+      )
+    }
   )
 )
 

--- a/runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
+++ b/runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
@@ -23,23 +23,21 @@ package fs2
 package grpc
 package client
 
-import cats.MonadError
+import cats.MonadThrow
 import cats.implicits._
 import cats.effect.kernel.Concurrent
 import cats.effect.std.{Dispatcher, Queue}
 import io.grpc.{ClientCall, Metadata, Status}
 
 class Fs2StreamClientCallListener[F[_], Response] private (
-    request: Int => Unit,
+    request: Int => F[Unit],
     queue: Queue[F, Either[GrpcStatus, Response]],
     dispatcher: Dispatcher[F]
-)(implicit F: MonadError[F, Throwable])
+)(implicit F: MonadThrow[F])
     extends ClientCall.Listener[Response] {
 
-  override def onMessage(message: Response): Unit = {
-    request(1)
+  override def onMessage(message: Response): Unit =
     dispatcher.unsafeRunSync(queue.offer(message.asRight))
-  }
 
   override def onClose(status: Status, trailers: Metadata): Unit =
     dispatcher.unsafeRunSync(queue.offer(GrpcStatus(status, trailers).asLeft))
@@ -48,7 +46,7 @@ class Fs2StreamClientCallListener[F[_], Response] private (
 
     val run: F[Option[Response]] =
       queue.take.flatMap {
-        case Right(v) => v.some.pure[F]
+        case Right(v) => v.some.pure[F] <* request(1)
         case Left(GrpcStatus(status, trailers)) =>
           if (!status.isOk) F.raiseError(status.asRuntimeException(trailers))
           else none[Response].pure[F]
@@ -60,8 +58,8 @@ class Fs2StreamClientCallListener[F[_], Response] private (
 
 object Fs2StreamClientCallListener {
 
-  def apply[F[_]: Concurrent, Response](
-      request: Int => Unit,
+  private[client] def apply[F[_]: Concurrent, Response](
+      request: Int => F[Unit],
       dispatcher: Dispatcher[F]
   ): F[Fs2StreamClientCallListener[F, Response]] =
     Queue.unbounded[F, Either[GrpcStatus, Response]].map { q =>

--- a/runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
+++ b/runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
@@ -68,7 +68,9 @@ class Fs2UnaryClientCallListener[F[_], Response] private (
 
 object Fs2UnaryClientCallListener {
 
-  def apply[F[_]: Async, Response](dispatcher: Dispatcher[F]): F[Fs2UnaryClientCallListener[F, Response]] =
+  private[client] def apply[F[_]: Async, Response](
+      dispatcher: Dispatcher[F]
+  ): F[Fs2UnaryClientCallListener[F, Response]] =
     (Deferred[F, GrpcStatus], Ref.of[F, Option[Response]](none)).mapN((response, value) =>
       new Fs2UnaryClientCallListener[F, Response](response, value, dispatcher)
     )


### PR DESCRIPTION
 - only request for more messages when stream is being pulled instead
   of unconditionally request for more through `onMessage`.

 - current behavior causes heap to fill up and eventually cause
   out of memory exceptions.

 - add test that showcases we only request more messages when there
   is a demand.

 - make listener constructors private to client as there is no need
   guarantee binary compat for implementation details.

 - adjust mima to exclude checks for methods made internal.