### PR TITLE
Remove MiMa exceptions for call listeners

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,14 +49,6 @@ inThisBuild(
   ) ++ List(
     spiewakCiReleaseSnapshots := false,
     spiewakMainBranches := Seq("master", "series/0.x")
-  ) ++ List(
-    mimaBinaryIssueFilters ++= {
-      Seq(
-        // Made internal
-        exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2UnaryClientCallListener.apply"),
-        exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2StreamClientCallListener.apply")
-      )
-    }
   )
 )
 

--- a/runtime/src/main/scala/client/Fs2ClientCall.scala
+++ b/runtime/src/main/scala/client/Fs2ClientCall.scala
@@ -101,12 +101,12 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (
 
   private def mkUnaryListenerR(md: Metadata): Resource[F, Fs2UnaryClientCallListener[F, Response]] =
     Resource.makeCase(
-      startListener(Fs2UnaryClientCallListener[F, Response](dispatcher), md)
+      startListener(Fs2UnaryClientCallListener.create[F, Response](dispatcher), md)
     )(handleExitCase(cancelSucceed = false))
 
   private def mkStreamListenerR(md: Metadata): Resource[F, Fs2StreamClientCallListener[F, Response]] =
     Resource.makeCase(
-      startListener(Fs2StreamClientCallListener[F, Response](request, dispatcher), md)
+      startListener(Fs2StreamClientCallListener.create[F, Response](request, dispatcher), md)
     )(handleExitCase(cancelSucceed = true))
 
 }

--- a/runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
+++ b/runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
@@ -23,7 +23,7 @@ package fs2
 package grpc
 package client
 
-import cats.MonadThrow
+import cats.{Applicative, MonadThrow}
 import cats.implicits._
 import cats.effect.kernel.Concurrent
 import cats.effect.std.{Dispatcher, Queue}
@@ -58,7 +58,14 @@ class Fs2StreamClientCallListener[F[_], Response] private (
 
 object Fs2StreamClientCallListener {
 
-  private[client] def apply[F[_]: Concurrent, Response](
+  @deprecated("Internal API. Will be removed from public API.", "1.1.4")
+  def apply[F[_]: Concurrent, Response](
+      request: Int => Unit,
+      dispatcher: Dispatcher[F]
+  ): F[Fs2StreamClientCallListener[F, Response]] =
+    create(request.andThen(Applicative[F].pure), dispatcher)
+
+  private[client] def create[F[_]: Concurrent, Response](
       request: Int => F[Unit],
       dispatcher: Dispatcher[F]
   ): F[Fs2StreamClientCallListener[F, Response]] =

--- a/runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
+++ b/runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
@@ -68,7 +68,13 @@ class Fs2UnaryClientCallListener[F[_], Response] private (
 
 object Fs2UnaryClientCallListener {
 
-  private[client] def apply[F[_]: Async, Response](
+  @deprecated("Internal API. Will be removed from public API.", "1.1.4")
+  def apply[F[_]: Async, Response](
+      dispatcher: Dispatcher[F]
+  ): F[Fs2UnaryClientCallListener[F, Response]] =
+    create(dispatcher)
+
+  private[client] def create[F[_]: Async, Response](
       dispatcher: Dispatcher[F]
   ): F[Fs2UnaryClientCallListener[F, Response]] =
     (Deferred[F, GrpcStatus], Ref.of[F, Option[Response]](none)).mapN((response, value) =>


### PR DESCRIPTION
We lose the nicer `apply` name, but don't have to make any exceptions.