### PR TITLE
runtime/codegen: introduce client options + allow for prefetching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,22 @@ inThisBuild(
   ) ++ List(
     spiewakCiReleaseSnapshots := false,
     spiewakMainBranches := Seq("master", "series/0.x")
+  ) ++ List(
+    mimaBinaryIssueFilters ++= Seq(
+      // Making constants private to codegen
+      exclude[DirectMissingMethodProblem]("fs2.grpc.codegen.Fs2GrpcServicePrinter#constants.*"),
+      // API that is not extended by end-users
+      exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.client"),
+      // API that is not intended to be used by end-users
+      exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2ClientCall#PartiallyAppliedClientCall.apply$extension"),
+      // Private to client
+      exclude[IncompatibleMethTypeProblem]("fs2.grpc.client.Fs2ClientCall.this"),
+      exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2StreamClientCallListener.this"),
+      exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2StreamClientCallListener.create"),
+      // Removing deprecated internal methods
+      exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2StreamClientCallListener.apply"),
+      exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2UnaryClientCallListener.apply")
+    )
   )
 )
 

--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -11,18 +11,18 @@ trait TestServiceFs2Grpc[F[_], A] {
 
 object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2Grpc] {
   
-  def client[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMeta: A => _root_.io.grpc.Metadata, coFn: _root_.io.grpc.CallOptions => _root_.io.grpc.CallOptions = identity, errorAdapter: _root_.io.grpc.StatusRuntimeException => Option[Exception] = _ => None): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
+  def client[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMetadata: A => _root_.io.grpc.Metadata, clientOptions: _root_.fs2.grpc.client.ClientOptions): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
     def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage] = {
-      _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, coFn(_root_.io.grpc.CallOptions.DEFAULT), dispatcher, errorAdapter).flatMap(_.unaryToUnaryCall(request, mkMeta(ctx)))
+      _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(request, mkMetadata(ctx)))
     }
     def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage] = {
-      _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, coFn(_root_.io.grpc.CallOptions.DEFAULT), dispatcher, errorAdapter).flatMap(_.streamingToUnaryCall(request, mkMeta(ctx)))
+      _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(request, mkMetadata(ctx)))
     }
     def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] = {
-      _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, coFn(_root_.io.grpc.CallOptions.DEFAULT), dispatcher, errorAdapter)).flatMap(_.unaryToStreamingCall(request, mkMeta(ctx)))
+      _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(request, mkMetadata(ctx)))
     }
     def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] = {
-      _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, coFn(_root_.io.grpc.CallOptions.DEFAULT), dispatcher, errorAdapter)).flatMap(_.streamingToStreamingCall(request, mkMeta(ctx)))
+      _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(request, mkMetadata(ctx)))
     }
   }
   

--- a/runtime/src/main/scala/client/ClientOptions.scala
+++ b/runtime/src/main/scala/client/ClientOptions.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package grpc
+package client
+
+import io.grpc.{StatusRuntimeException, CallOptions}
+
+sealed abstract class ClientOptions private (
+    val prefetchN: Int,
+    val callOptionsFn: CallOptions => CallOptions,
+    val errorAdapter: PartialFunction[StatusRuntimeException, Exception]
+) {
+
+  private def copy(
+      prefetchN: Int = this.prefetchN,
+      callOptionsFn: CallOptions => CallOptions = this.callOptionsFn,
+      errorAdapter: PartialFunction[StatusRuntimeException, Exception] = this.errorAdapter
+  ): ClientOptions =
+    new ClientOptions(prefetchN, callOptionsFn, errorAdapter) {}
+
+  /** Prefetch up to @param n messages from a server. The client will
+    * try to keep the internal buffer filled according to the provided
+    * value.
+    *
+    * If the provided value is less than 1 it defaults to 1.
+    */
+  def withPrefetchN(n: Int): ClientOptions =
+    copy(prefetchN = math.max(n, 1))
+
+  /** Adapt `io.grpc.StatusRuntimeException` into a different exception.
+    */
+  def withErrorAdapter(ea: PartialFunction[StatusRuntimeException, Exception]): ClientOptions =
+    copy(errorAdapter = ea)
+
+  /** Function that is applied on `io.grpc.CallOptions.DEFAULT`
+    * for each new RPC call.
+    */
+  def withCallOptionsFn(fn: CallOptions => CallOptions): ClientOptions =
+    copy(callOptionsFn = fn)
+
+}
+
+object ClientOptions {
+
+  val default: ClientOptions = new ClientOptions(
+    prefetchN = 1,
+    callOptionsFn = identity,
+    errorAdapter = PartialFunction.empty[StatusRuntimeException, Exception]
+  ) {}
+
+}

--- a/runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
+++ b/runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
@@ -68,12 +68,6 @@ class Fs2UnaryClientCallListener[F[_], Response] private (
 
 object Fs2UnaryClientCallListener {
 
-  @deprecated("Internal API. Will be removed from public API.", "1.1.4")
-  def apply[F[_]: Async, Response](
-      dispatcher: Dispatcher[F]
-  ): F[Fs2UnaryClientCallListener[F, Response]] =
-    create(dispatcher)
-
   private[client] def create[F[_]: Async, Response](
       dispatcher: Dispatcher[F]
   ): F[Fs2UnaryClientCallListener[F, Response]] =

--- a/runtime/src/main/scala/client/StreamIngest.scala
+++ b/runtime/src/main/scala/client/StreamIngest.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package grpc
+package client
+
+import cats.implicits._
+import cats.effect.kernel.{Concurrent, Ref}
+import cats.effect.std.Queue
+
+private[client] trait StreamIngest[F[_], T] {
+  def onMessage(msg: T): F[Unit]
+  def onClose(status: GrpcStatus): F[Unit]
+  def messages: Stream[F, T]
+}
+
+private[client] object StreamIngest {
+
+  def apply[F[_]: Concurrent, T](
+      request: Int => F[Unit],
+      prefetchN: Int
+  ): F[StreamIngest[F, T]] =
+    (Concurrent[F].ref(prefetchN), Queue.unbounded[F, Either[GrpcStatus, T]])
+      .mapN((d, q) => create[F, T](request, prefetchN, d, q)) <* request(prefetchN)
+
+  def create[F[_], T](
+      request: Int => F[Unit],
+      prefetchN: Int,
+      demand: Ref[F, Int],
+      queue: Queue[F, Either[GrpcStatus, T]]
+  )(implicit F: Concurrent[F]): StreamIngest[F, T] = new StreamIngest[F, T] {
+
+    def onMessage(msg: T): F[Unit] =
+      decreaseDemandBy(1) *> queue.offer(msg.asRight) *> ensureMessages(prefetchN)
+
+    def onClose(status: GrpcStatus): F[Unit] =
+      queue.offer(status.asLeft)
+
+    def ensureMessages(nextWhenEmpty: Int): F[Unit] =
+      (demand.get, queue.size).mapN((cd, qs) => fetch(nextWhenEmpty).whenA((cd + qs) < 1)).flatten
+
+    def decreaseDemandBy(n: Int): F[Unit] =
+      demand.update(d => math.max(d - n, 0))
+
+    def increaseDemandBy(n: Int): F[Unit] =
+      demand.update(_ + n)
+
+    def fetch(n: Int): F[Unit] =
+      request(n) *> increaseDemandBy(n)
+
+    val messages: Stream[F, T] = {
+
+      val run: F[Option[T]] =
+        queue.take.flatMap {
+          case Right(v) => v.some.pure[F] <* ensureMessages(prefetchN)
+          case Left(GrpcStatus(status, trailers)) =>
+            if (!status.isOk) F.raiseError(status.asRuntimeException(trailers))
+            else none[T].pure[F]
+        }
+
+      Stream.repeatEval(run).unNoneTerminate
+
+    }
+
+  }
+
+}

--- a/runtime/src/test/scala/client/StreamIngestSuite.scala
+++ b/runtime/src/test/scala/client/StreamIngestSuite.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package grpc
+package client
+
+import scala.concurrent.duration._
+import cats.effect._
+import munit._
+
+class StreamIngestSuite extends CatsEffectSuite with CatsEffectFunFixtures {
+
+  test("basic") {
+
+    def run(prefetchN: Int, takeN: Int, expectedReq: Int, expectedCount: Int) = {
+      for {
+        ref <- IO.ref(0)
+        ingest <- StreamIngest[IO, Int](req => ref.update(_ + req), prefetchN)
+        _ <- Stream.emits((1 to prefetchN)).evalTap(ingest.onMessage).compile.drain
+        messages <- ingest.messages.take(takeN.toLong).compile.toList
+        requested <- ref.get
+      } yield {
+        assertEquals(messages.size, expectedCount)
+        assertEquals(requested, expectedReq)
+      }
+    }
+
+    run(prefetchN = 1, takeN = 1, expectedReq = 2 /* queue becomes empty */, expectedCount = 1) *>
+      run(prefetchN = 2, takeN = 1, expectedReq = 2, expectedCount = 1) *>
+      run(prefetchN = 1024, takeN = 1024, expectedReq = 2048 /* queue becomes empty */, expectedCount = 1024) *>
+      run(prefetchN = 1024, takeN = 1023, expectedReq = 1024, expectedCount = 1023)
+
+  }
+
+  test("producer slower") {
+
+    def run(prefetchN: Int, takeN: Int, expectedReq: Int, expectedCount: Int, delay: FiniteDuration) = {
+      for {
+        ref <- IO.ref(0)
+        ingest <- StreamIngest[IO, Int](req => ref.update(_ + req), prefetchN)
+        worker <- Stream
+          .emits((1 to prefetchN))
+          .evalTap(m => IO.sleep(delay) *> ingest.onMessage(m))
+          .compile
+          .drain
+          .start
+        messages <- ingest.messages.take(takeN.toLong).compile.toList
+        requested <- ref.get
+        _ <- worker.cancel
+      } yield {
+        assertEquals(messages.size, expectedCount)
+        assertEquals(requested, expectedReq)
+      }
+    }
+
+    run(prefetchN = 5, takeN = 1, expectedReq = 5, expectedCount = 1, delay = 200.millis) *>
+      run(prefetchN = 10, takeN = 5, expectedReq = 10, expectedCount = 5, delay = 200.millis) *>
+      run(prefetchN = 10, takeN = 10, expectedReq = 20, expectedCount = 10, delay = 200.millis)
+
+  }
+
+  test("consumer slower") {
+
+    def run(prefetchN: Int, takeN: Int, expectedReq: Int, expectedCount: Int, delay: FiniteDuration) = {
+      for {
+        ref <- IO.ref(0)
+        ingest <- StreamIngest[IO, Int](req => ref.update(_ + req), prefetchN)
+        worker <- Stream
+          .emits((1 to prefetchN))
+          .evalTap(ingest.onMessage)
+          .compile
+          .drain
+          .start
+        messages <- ingest.messages.evalTap(_ => IO.sleep(delay)).take(takeN.toLong).compile.toList
+        requested <- ref.get
+        _ <- worker.cancel
+      } yield {
+        assertEquals(messages.size, expectedCount)
+        assertEquals(requested, expectedReq)
+      }
+    }
+
+    run(prefetchN = 5, takeN = 1, expectedReq = 5, expectedCount = 1, delay = 200.millis) *>
+      run(prefetchN = 10, takeN = 5, expectedReq = 10, expectedCount = 5, delay = 200.millis) *>
+      run(prefetchN = 10, takeN = 10, expectedReq = 20, expectedCount = 10, delay = 200.millis)
+
+  }
+
+}


### PR DESCRIPTION
 - introduce client options
 - allow for prefetching messages 
 - remove deprecated methods

@rossabaker The prefetching addition is an improvement in that this allows us to make one call to request, say, 1000 messages. My thinking is that further improvements can be done on the consumer side by using fs2 `groupWithin` or `prefetchN`.

This is a breaking change such that we can clean a bit up and polish the user API wrt. `ClientOptions`. I'll look into backporting to 0.x series without breaking changes if you think this PR is ok.