### PR TITLE
java-runtime: use same strategy as in main branch.

### DIFF
--- a/java-runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
+++ b/java-runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
@@ -2,49 +2,33 @@ package org.lyranthe.fs2_grpc
 package java_runtime
 package client
 
-import cats.effect.{Effect, ConcurrentEffect, Sync}
-import cats.implicits._
-import fs2.{Pull, Stream}
-import fs2.concurrent.Queue
+import cats.syntax.all._
+import cats.effect._
+import fs2.Stream
 import io.grpc.{ClientCall, Metadata, Status}
 
-class Fs2StreamClientCallListener[F[_]: Effect, Response](
-    request: Int => Unit,
-    queue: Queue[F, Either[GrpcStatus, Response]]
+private[client] class Fs2StreamClientCallListener[F[_]: Effect, Response](
+    ingest: StreamIngest[F, Response]
 ) extends ClientCall.Listener[Response] {
 
-  private val requestOne: F[Unit] =
-    Sync[F].delay(request(1))
-
   override def onMessage(message: Response): Unit =
-    queue.enqueue1(message.asRight).unsafeRun()
+    ingest.onMessage(message).unsafeRun()
 
   override def onClose(status: Status, trailers: Metadata): Unit =
-    queue.enqueue1(GrpcStatus(status, trailers).asLeft).unsafeRun()
+    ingest.onClose(GrpcStatus(status, trailers)).unsafeRun()
 
-  def stream: Stream[F, Response] = {
+  val stream: Stream[F, Response] = ingest.messages
 
-    def go(q: Stream[F, Either[GrpcStatus, Response]]): Pull[F, Response, Unit] = {
-      q.pull.uncons1.flatMap {
-        case Some((Right(v), tl)) => Pull.output1(v) >> go(tl)
-        case Some((Left(GrpcStatus(status, trailers)), _)) =>
-          if (!status.isOk)
-            Pull.raiseError[F](status.asRuntimeException(trailers))
-          else
-            Pull.done
-        case None => Pull.done
-      }
-    }
-
-    go(queue.dequeue).stream.evalTap(_ => requestOne)
-  }
 }
 
-object Fs2StreamClientCallListener {
+private[client] object Fs2StreamClientCallListener {
 
-  def apply[F[_]: ConcurrentEffect, Response](request: Int => Unit): F[Fs2StreamClientCallListener[F, Response]] =
-    Queue
-      .unbounded[F, Either[GrpcStatus, Response]]
-      .map(new Fs2StreamClientCallListener[F, Response](request, _))
+  def apply[F[_], Response](
+      request: Int => F[Unit],
+      prefetchN: Int
+  )(implicit F: ConcurrentEffect[F]): F[Fs2StreamClientCallListener[F, Response]] =
+    StreamIngest[F, Response](request, prefetchN).map(
+      new Fs2StreamClientCallListener[F, Response](_)
+    )
 
 }

--- a/java-runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
+++ b/java-runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
@@ -7,8 +7,11 @@ import cats.effect.concurrent.{Deferred, Ref}
 import cats.implicits._
 import io.grpc._
 
-class Fs2UnaryClientCallListener[F[_], Response](grpcStatus: Deferred[F, GrpcStatus], value: Ref[F, Option[Response]])(
-    implicit F: Effect[F]
+private[client] class Fs2UnaryClientCallListener[F[_], Response](
+    grpcStatus: Deferred[F, GrpcStatus],
+    value: Ref[F, Option[Response]]
+)(implicit
+    F: Effect[F]
 ) extends ClientCall.Listener[Response] {
 
   override def onClose(status: Status, trailers: Metadata): Unit =
@@ -41,7 +44,7 @@ class Fs2UnaryClientCallListener[F[_], Response](grpcStatus: Deferred[F, GrpcSta
   }
 }
 
-object Fs2UnaryClientCallListener {
+private[client] object Fs2UnaryClientCallListener {
 
   def apply[F[_]: ConcurrentEffect, Response]: F[Fs2UnaryClientCallListener[F, Response]] = {
     (Deferred[F, GrpcStatus], Ref.of[F, Option[Response]](none)).mapN((response, value) =>

--- a/java-runtime/src/main/scala/client/StreamIngest.scala
+++ b/java-runtime/src/main/scala/client/StreamIngest.scala
@@ -1,0 +1,67 @@
+package org.lyranthe.fs2_grpc
+package java_runtime
+package client
+
+import cats.syntax.all._
+import cats.effect._
+import cats.effect.concurrent.Ref
+import fs2.Stream
+import fs2.concurrent.InspectableQueue
+
+private[client] trait StreamIngest[F[_], T] {
+  def onMessage(msg: T): F[Unit]
+  def onClose(status: GrpcStatus): F[Unit]
+  def messages: Stream[F, T]
+}
+
+private[client] object StreamIngest {
+
+  def apply[F[_]: ConcurrentEffect, T](
+      request: Int => F[Unit],
+      prefetchN: Int
+  ): F[StreamIngest[F, T]] =
+    (Ref.of[F, Int](prefetchN), InspectableQueue.unbounded[F, Either[GrpcStatus, T]])
+      .mapN((d, q) => create[F, T](request, prefetchN, d, q)) <* request(prefetchN)
+
+  def create[F[_], T](
+      request: Int => F[Unit],
+      prefetchN: Int,
+      demand: Ref[F, Int],
+      queue: InspectableQueue[F, Either[GrpcStatus, T]]
+  )(implicit F: ConcurrentEffect[F]): StreamIngest[F, T] = new StreamIngest[F, T] {
+
+    def onMessage(msg: T): F[Unit] =
+      decreaseDemandBy(1) *> queue.enqueue1(msg.asRight)
+
+    def onClose(status: GrpcStatus): F[Unit] =
+      queue.enqueue1(status.asLeft)
+
+    def ensureMessages(nextWhenEmpty: Int): F[Unit] = (demand.get, queue.getSize)
+      .mapN((cd, qs) => fetch(nextWhenEmpty).whenA((cd + qs) < 1))
+      .flatten
+
+    def decreaseDemandBy(n: Int): F[Unit] =
+      demand.update(d => math.max(d - n, 0))
+
+    def increaseDemandBy(n: Int): F[Unit] =
+      demand.update(_ + n)
+
+    def fetch(n: Int): F[Unit] =
+      request(n) *> increaseDemandBy(n)
+
+    val messages: Stream[F, T] = {
+
+      val run: F[Option[T]] =
+        queue.dequeue1.flatMap {
+          case Right(v) => v.some.pure[F] <* ensureMessages(prefetchN)
+          case Left(GrpcStatus(status, trailers)) =>
+            if (!status.isOk) F.raiseError(status.asRuntimeException(trailers))
+            else none[T].pure[F]
+        }
+
+      Stream.repeatEval(run).unNoneTerminate
+    }
+
+  }
+
+}

--- a/java-runtime/src/test/scala/client/ClientSuite.scala
+++ b/java-runtime/src/test/scala/client/ClientSuite.scala
@@ -15,7 +15,7 @@ import scala.util.Success
 object ClientSuite extends SimpleTestSuite {
 
   def fs2ClientCall(dummy: DummyClientCall) =
-    new Fs2ClientCall[IO, String, Int](dummy, _ => None)
+    new Fs2ClientCall[IO, String, Int](dummy, _ => None, 1)
 
   test("single message to unaryToUnary") {
 
@@ -187,7 +187,7 @@ object ClientSuite extends SimpleTestSuite {
     ec.tick()
     assertEquals(result.value, Some(Success(List(1, 2, 3))))
     assertEquals(dummy.messagesSent.size, 1)
-    assertEquals(dummy.requested, 4)
+    assertEquals(dummy.requested, 2)
   }
 
   test("single message to unaryToStreaming - back pressure") {
@@ -214,9 +214,7 @@ object ClientSuite extends SimpleTestSuite {
 
     assertEquals(result.value, Some(Success(List(1, 2))))
     assertEquals(dummy.messagesSent.size, 1)
-
-    // One initial when starting listener + two for take(2)
-    assertEquals(dummy.requested, 3)
+    assertEquals(dummy.requested, 1)
   }
 
   test("stream to streamingToStreaming") {
@@ -246,7 +244,7 @@ object ClientSuite extends SimpleTestSuite {
     ec.tick()
     assertEquals(result.value, Some(Success(List(1, 2, 3))))
     assertEquals(dummy.messagesSent.size, 5)
-    assertEquals(dummy.requested, 4)
+    assertEquals(dummy.requested, 2)
   }
 
   test("cancellation for streamingToStreaming") {
@@ -316,7 +314,7 @@ object ClientSuite extends SimpleTestSuite {
       Status.INTERNAL
     )
     assertEquals(dummy.messagesSent.size, 5)
-    assertEquals(dummy.requested, 4)
+    assertEquals(dummy.requested, 2)
   }
 
   test("resource awaits termination of managed channel") {
@@ -352,7 +350,7 @@ object ClientSuite extends SimpleTestSuite {
         }
 
         val dummy = new DummyClientCall()
-        val client = new Fs2ClientCall[IO, String, Int](dummy, adapter)
+        val client = new Fs2ClientCall[IO, String, Int](dummy, adapter, 1)
         val result = call(client).unsafeToFuture()
 
         dummy.listener.get.onClose(status, new Metadata())

--- a/java-runtime/src/test/scala/client/StreamIngestSuite.scala
+++ b/java-runtime/src/test/scala/client/StreamIngestSuite.scala
@@ -1,0 +1,40 @@
+package org.lyranthe.fs2_grpc
+package java_runtime
+package client
+
+import scala.concurrent.ExecutionContext
+import cats.effect._
+import cats.effect.concurrent.Ref
+import minitest._
+
+object StreamIngestSuite extends SimpleTestSuite {
+
+  implicit val CS: ContextShift[IO] =
+    IO.contextShift(ExecutionContext.global)
+
+  test("basic") {
+
+    def run(prefetchN: Int, takeN: Int, expectedReq: Int, expectedCount: Int) = {
+      for {
+        ref <- Ref.of[IO, Int](0)
+        ingest <- StreamIngest[IO, Int](req => ref.update(_ + req), prefetchN)
+        _ <- fs2.Stream.emits((1 to prefetchN)).evalTap(m => ingest.onMessage(m)).compile.drain
+        messages <- ingest.messages.take(takeN.toLong).compile.toList
+        requested <- ref.get
+      } yield {
+        assertEquals(messages.size, expectedCount)
+        assertEquals(requested, expectedReq)
+      }
+    }
+
+    val test =
+      run(prefetchN = 1, takeN = 1, expectedReq = 2 /* queue becomes empty */, expectedCount = 1) *>
+        run(prefetchN = 2, takeN = 1, expectedReq = 2, expectedCount = 1) *>
+        run(prefetchN = 1024, takeN = 1024, expectedReq = 2048 /* queue becomes empty */, expectedCount = 1024) *>
+        run(prefetchN = 1024, takeN = 1023, expectedReq = 1024, expectedCount = 1023)
+
+    test.unsafeRunSync()
+
+  }
+
+}


### PR DESCRIPTION
Use same strategy as in main branch with regards to prefetching in `Fs2StreamClientCallListener`.

 - difference is that one uses `CallOptions` to set
   the value of `prefetchN`, e.g.

   `callOptions.withOption(Fs2ClientCall.prefetchNKey, 10)`

   This is done in order not to wrech too much havoc in the
   public API and avoiding to touch the code generator.

 - `Fs2StreamClientCallListener` now uses `StreamIngest` that
   is similar to that in the main branch.