### PR TITLE
build: Scala 3.0.0 final!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.0-RC3, 2.13.5, 2.12.13]
+        scala: [3.0.0, 2.13.5, 2.12.13]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.5]
+        scala: [3.0.0]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -100,12 +100,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (3.0.0-RC3)
+      - name: Download target directories (3.0.0)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.0.0-RC3-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.0.0-${{ matrix.java }}
 
-      - name: Inflate target directories (3.0.0-RC3)
+      - name: Inflate target directories (3.0.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.core.ProblemFilters._
 import Dependencies._
 
-lazy val Scala3 = "3.0.0-RC3"
+lazy val Scala3 = "3.0.0"
 lazy val Scala213 = "2.13.5"
 lazy val Scala212 = "2.12.13"
 
@@ -15,7 +15,7 @@ def dev(ghUser: String, name: String, email: String): Developer =
 
 inThisBuild(
   List(
-    scalaVersion := Scala213,
+    scalaVersion := Scala3,
     crossScalaVersions := List(Scala3, Scala213, Scala212),
     baseVersion := "1.0",
     versionIntroduced := Map(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
     val grpc = scalapb.compiler.Version.grpcJavaVersion
     val scalaPb = scalapb.compiler.Version.scalapbVersion
 
-    val fs2 = "3.0.2"
-    val catsEffect = "3.1.0"
-    val ceMunit = "1.0.2"
+    val fs2 = "3.0.3"
+    val catsEffect = "3.1.1"
+    val ceMunit = "1.0.3"
 
     val sbtProtoc = "1.0.3"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,6 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.3")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc-gen-project" % "0.1.7")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.2"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"
+// TODO: Remove when sbt-spiewak does not use sbt-dotty
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
 - sbt-spiewak depends on an outdated sbt-dotty version,
   which is why it needs to be added here temporarily until
   sbt-spiewak removes it.