### PR TITLE
codegen/runtime: add server options - clean up API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,50 @@ inThisBuild(
       exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2StreamClientCallListener.create"),
       // Removing deprecated internal methods
       exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2StreamClientCallListener.apply"),
-      exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2UnaryClientCallListener.apply")
+      exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2UnaryClientCallListener.apply"),
+      // Making it to 2.0
+      exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.serviceBinding"),
+      exclude[DirectMissingMethodProblem]("fs2.grpc.GeneratedCompanion.*"),
+      exclude[DirectMissingMethodProblem]("fs2.grpc.server.ServerCallOptions.*"),
+      exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2ClientCall#PartiallyAppliedClientCall.apply"),
+      exclude[DirectMissingMethodProblem](
+        "fs2.grpc.server.Fs2StreamServerCallListener#PartialFs2StreamServerCallListener.apply$default$3$extension"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "fs2.grpc.server.Fs2UnaryServerCallListener#PartialFs2UnaryServerCallListener.apply$default$3"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "fs2.grpc.server.Fs2StreamServerCallListener#PartialFs2StreamServerCallListener.apply$default$3"
+      ),
+      exclude[DirectMissingMethodProblem](
+        "fs2.grpc.server.Fs2UnaryServerCallListener#PartialFs2UnaryServerCallListener.apply$default$3$extension"
+      ),
+      exclude[IncompatibleMethTypeProblem]("fs2.grpc.server.Fs2ServerCall.*"),
+      exclude[DirectMissingMethodProblem]("fs2.grpc.server.Fs2ServerCallHandler.*"),
+      exclude[IncompatibleMethTypeProblem](
+        "fs2.grpc.server.Fs2StreamServerCallListener#PartialFs2StreamServerCallListener.apply$extension"
+      ),
+      exclude[IncompatibleResultTypeProblem](
+        "fs2.grpc.server.Fs2StreamServerCallListener#PartialFs2StreamServerCallListener.apply$default$3$extension"
+      ),
+      exclude[IncompatibleMethTypeProblem](
+        "fs2.grpc.server.Fs2UnaryServerCallListener#PartialFs2UnaryServerCallListener.apply"
+      ),
+      exclude[IncompatibleResultTypeProblem](
+        "fs2.grpc.server.Fs2UnaryServerCallListener#PartialFs2UnaryServerCallListener.apply$default$3"
+      ),
+      exclude[IncompatibleMethTypeProblem](
+        "fs2.grpc.server.Fs2StreamServerCallListener#PartialFs2StreamServerCallListener.apply"
+      ),
+      exclude[IncompatibleResultTypeProblem](
+        "fs2.grpc.server.Fs2StreamServerCallListener#PartialFs2StreamServerCallListener.apply$default$3"
+      ),
+      exclude[IncompatibleMethTypeProblem](
+        "fs2.grpc.server.Fs2UnaryServerCallListener#PartialFs2UnaryServerCallListener.apply$extension"
+      ),
+      exclude[IncompatibleResultTypeProblem](
+        "fs2.grpc.server.Fs2UnaryServerCallListener#PartialFs2UnaryServerCallListener.apply$default$3$extension"
+      )
     )
   )
 )

--- a/codegen/src/main/scala/Fs2GrpcServicePrinter.scala
+++ b/codegen/src/main/scala/Fs2GrpcServicePrinter.scala
@@ -79,7 +79,7 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, serviceSuffix: String, d
     val inType = method.inputType.scalaType
     val outType = method.outputType.scalaType
     val descriptor = method.grpcDescriptor.fullName
-    val handler = s"$Fs2ServerCallHandler[F](dispatcher).${handleMethod(method)}[$inType, $outType]"
+    val handler = s"$Fs2ServerCallHandler[F](dispatcher, serverOptions).${handleMethod(method)}[$inType, $outType]"
 
     val serviceCall = s"serviceImpl.${method.name}"
     val eval = if (method.isServerStreaming) s"$Stream.eval(mkCtx(m))" else "mkCtx(m)"
@@ -122,7 +122,7 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, serviceSuffix: String, d
 
   private[this] def serviceBinding: PrinterEndo = {
     _.add(
-      s"protected def serviceBinding[F[_]: $Async, $Ctx](dispatcher: $Dispatcher[F], serviceImpl: $serviceNameFs2[F, $Ctx], mkCtx: $Metadata => F[$Ctx]): $ServerServiceDefinition = {"
+      s"protected def serviceBinding[F[_]: $Async, $Ctx](dispatcher: $Dispatcher[F], serviceImpl: $serviceNameFs2[F, $Ctx], mkCtx: $Metadata => F[$Ctx], serverOptions: $ServerOptions): $ServerServiceDefinition = {"
     ).indent
       .add(s"$ServerServiceDefinition")
       .call(serviceBindingImplementations)
@@ -162,6 +162,7 @@ object Fs2GrpcServicePrinter {
     val Fs2ServerCallHandler = s"$fs2grpcPkg.server.Fs2ServerCallHandler"
     val Fs2ClientCall = s"$fs2grpcPkg.client.Fs2ClientCall"
     val ClientOptions = s"$fs2grpcPkg.client.ClientOptions"
+    val ServerOptions = s"$fs2grpcPkg.server.ServerOptions"
     val Companion = s"$fs2grpcPkg.GeneratedCompanion"
 
     val ServerServiceDefinition = s"$grpcPkg.ServerServiceDefinition"

--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -26,13 +26,13 @@ object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestService
     }
   }
   
-  protected def serviceBinding[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], serviceImpl: TestServiceFs2Grpc[F, A], mkCtx: _root_.io.grpc.Metadata => F[A]): _root_.io.grpc.ServerServiceDefinition = {
+  protected def serviceBinding[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], serviceImpl: TestServiceFs2Grpc[F, A], mkCtx: _root_.io.grpc.Metadata => F[A], serverOptions: _root_.fs2.grpc.server.ServerOptions): _root_.io.grpc.ServerServiceDefinition = {
     _root_.io.grpc.ServerServiceDefinition
       .builder(hello.world.TestServiceGrpc.SERVICE)
-      .addMethod(hello.world.TestServiceGrpc.METHOD_NO_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.noStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.clientStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.serverStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.bothStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_NO_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.noStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.clientStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.serverStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.bothStreaming(r, _))))
       .build()
   }
 

--- a/runtime/src/main/scala/client/Fs2ClientCall.scala
+++ b/runtime/src/main/scala/client/Fs2ClientCall.scala
@@ -119,23 +119,6 @@ object Fs2ClientCall {
 
   class PartiallyAppliedClientCall[F[_]](val dummy: Boolean = false) extends AnyVal {
 
-    @deprecated("Will be removed from public API - use alternative overload.", "1.2.0")
-    def apply[Request, Response](
-        channel: Channel,
-        methodDescriptor: MethodDescriptor[Request, Response],
-        callOptions: CallOptions,
-        dispatcher: Dispatcher[F],
-        errorAdapter: StatusRuntimeException => Option[Exception]
-    )(implicit F: Async[F]): F[Fs2ClientCall[F, Request, Response]] =
-      apply[Request, Response](
-        channel,
-        methodDescriptor,
-        dispatcher,
-        ClientOptions.default
-          .withCallOptionsFn(_ => callOptions)
-          .withErrorAdapter(Function.unlift(errorAdapter))
-      )
-
     def apply[Request, Response](
         channel: Channel,
         methodDescriptor: MethodDescriptor[Request, Response],

--- a/runtime/src/main/scala/server/Fs2StreamServerCallListener.scala
+++ b/runtime/src/main/scala/server/Fs2StreamServerCallListener.scala
@@ -61,7 +61,7 @@ object Fs2StreamServerCallListener {
     private[server] def apply[Request, Response](
         call: ServerCall[Request, Response],
         dispatcher: Dispatcher[F],
-        options: ServerCallOptions = ServerCallOptions.default
+        options: ServerOptions
     )(implicit F: Async[F]): F[Fs2StreamServerCallListener[F, Request, Response]] = for {
       inputQ <- Queue.unbounded[F, Option[Request]]
       isCancelled <- Deferred[F, Unit]

--- a/runtime/src/main/scala/server/Fs2UnaryServerCallListener.scala
+++ b/runtime/src/main/scala/server/Fs2UnaryServerCallListener.scala
@@ -80,7 +80,7 @@ object Fs2UnaryServerCallListener {
     private[server] def apply[Request, Response](
         call: ServerCall[Request, Response],
         dispatch: Dispatcher[F],
-        options: ServerCallOptions = ServerCallOptions.default
+        options: ServerOptions
     )(implicit F: Async[F]): F[Fs2UnaryServerCallListener[F, Request, Response]] = for {
       request <- Ref.of[F, Option[Request]](none)
       isComplete <- Deferred[F, Unit]

--- a/runtime/src/main/scala/server/ServerCallOptions.scala
+++ b/runtime/src/main/scala/server/ServerCallOptions.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package grpc
+package server
+
+sealed abstract class ServerCompressor(val name: String) extends Product with Serializable
+case object GzipCompressor extends ServerCompressor("gzip")
+
+sealed abstract class ServerCallOptions private (
+    val compressor: Option[ServerCompressor],
+    val messageCompression: Boolean
+) {
+
+  private def copy(
+      compressor: Option[ServerCompressor] = this.compressor,
+      messageCompression: Boolean = this.messageCompression
+  ): ServerCallOptions =
+    new ServerCallOptions(compressor, messageCompression) {}
+
+  /** Enables per-message compression.  If no message encoding has been negotiated,
+    * this is a no-op. By default per-message compression is enabled,
+    * but may not have any effect if compression is not enabled on the call.
+    */
+  def withMessageCompression(enabled: Boolean): ServerCallOptions =
+    copy(messageCompression = enabled)
+
+  /** Sets the compression algorithm for a call. Default gRPC
+    * servers support the "gzip" compressor.
+    */
+  def withServerCompressor(sc: Option[ServerCompressor]): ServerCallOptions =
+    copy(compressor = sc)
+
+}
+
+object ServerCallOptions {
+  val default: ServerCallOptions = new ServerCallOptions(
+    compressor = None,
+    messageCompression = true
+  ) {}
+}


### PR DESCRIPTION
 - add `ServerOptions` as a way to avoid breaking
   API going forward using a builder class for options
   when using `service` methods.