### PR TITLE
Reduce the number of unsafeRun* calls in fs2-grpc

### DIFF
--- a/runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
+++ b/runtime/src/main/scala/client/Fs2UnaryClientCallListener.scala
@@ -40,7 +40,7 @@ class Fs2UnaryClientCallListener[F[_], Response] private (
     dispatcher.unsafeRunSync(grpcStatus.complete(GrpcStatus(status, trailers)).void)
 
   override def onMessage(message: Response): Unit =
-    dispatcher.unsafeRunSync(value.set(message.some).void)
+    dispatcher.unsafeRunSync(value.set(message.some))
 
   def getValue: F[Response] = {
     for {


### PR DESCRIPTION
While it may be impossible to completely remove unsafeRun* calls while depending on the Java API, this at least reduces the number of calls needed for setup of each request (by one).