### PR TITLE
Add implicit of companion object

### DIFF
--- a/codegen/src/main/scala/Fs2GrpcServicePrinter.scala
+++ b/codegen/src/main/scala/Fs2GrpcServicePrinter.scala
@@ -104,12 +104,17 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, serviceSuffix: String, d
 
   private[this] def serviceObject: PrinterEndo =
     _.add(s"object $serviceNameFs2 extends $Companion[$serviceNameFs2] {").indent.newline
+      .call(serviceCompanion)
+      .newline
       .call(serviceClient)
       .newline
       .call(serviceBinding)
       .outdent
       .newline
       .add("}")
+
+  private[this] def serviceCompanion: PrinterEndo =
+    _.add(s"implicit def serviceCompanion: $Companion[$serviceNameFs2] = this")
 
   private[this] def serviceClient: PrinterEndo = {
     _.add(

--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -11,6 +11,8 @@ trait TestServiceFs2Grpc[F[_], A] {
 
 object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2Grpc] {
   
+  implicit def serviceCompanion: _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2Grpc] = this
+  
   def client[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMetadata: A => _root_.io.grpc.Metadata, clientOptions: _root_.fs2.grpc.client.ClientOptions): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
     def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage] = {
       _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(request, mkMetadata(ctx)))


### PR DESCRIPTION
I want to create ServerServiceDefinition more simply like following expression.
```
someServiceImpl[F].bindServiceResource[F] //Resource[F, ServerServiceDefinition]
```

This PR just add implicit of companion object like ScalaPB for this kind of expression.
