### PR TITLE
deps: update munit-cats-effect-3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
     val fs2 = "3.1.5"
     val catsEffect = "3.2.9"
-    val ceMunit = "1.0.5"
+    val ceMunit = "1.0.6"
 
     val sbtProtoc = "1.0.4"
 

--- a/runtime/src/test/scala/Fs2GrpcSuite.scala
+++ b/runtime/src/test/scala/Fs2GrpcSuite.scala
@@ -22,7 +22,7 @@
 package fs2
 package grpc
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, ExecutionContext}
 import scala.concurrent.duration.FiniteDuration
 import cats.effect.IO
 import cats.effect.std.Dispatcher
@@ -31,6 +31,13 @@ import cats.effect.unsafe.{IORuntime, IORuntimeConfig, Scheduler}
 import munit._
 
 class Fs2GrpcSuite extends CatsEffectSuite with CatsEffectFunFixtures {
+
+  private val parasiticExecutionContext = new ExecutionContext {
+    def execute(runnable: Runnable): Unit = runnable.run()
+    def reportFailure(cause: Throwable): Unit = cause.printStackTrace()
+  }
+
+  override val munitExecutionContext: ExecutionContext = parasiticExecutionContext
 
   protected def createDeterministicRuntime: (TestContext, IORuntime) = {
 


### PR DESCRIPTION
I had to restore the execution context change that happened [here](https://github.com/typelevel/munit-cats-effect/pull/124) in order to get server streaming to streaming cancellation tests to pass.