### PR TITLE
runtime: stream ingest tweaks

### DIFF
--- a/runtime/src/test/scala/client/ClientSuite.scala
+++ b/runtime/src/test/scala/client/ClientSuite.scala
@@ -189,7 +189,7 @@ class ClientSuite extends Fs2GrpcSuite {
     tc.tick()
     assertEquals(result.value, Some(Success(List(1, 2, 3))))
     assertEquals(dummy.messagesSent.size, 1)
-    assertEquals(dummy.requested, 3)
+    assertEquals(dummy.requested, 2)
 
   }
 
@@ -215,7 +215,7 @@ class ClientSuite extends Fs2GrpcSuite {
 
     assertEquals(result.value, Some(Success(List(1, 2))))
     assertEquals(dummy.messagesSent.size, 1)
-    assertEquals(dummy.requested, 2)
+    assertEquals(dummy.requested, 1)
   }
 
   runTest0("stream to streamingToStreaming") { (tc, io, d) =>
@@ -243,7 +243,7 @@ class ClientSuite extends Fs2GrpcSuite {
     tc.tick()
     assertEquals(result.value, Some(Success(List(1, 2, 3))))
     assertEquals(dummy.messagesSent.size, 5)
-    assertEquals(dummy.requested, 3)
+    assertEquals(dummy.requested, 2)
 
   }
 
@@ -308,7 +308,7 @@ class ClientSuite extends Fs2GrpcSuite {
       Status.INTERNAL
     )
     assertEquals(dummy.messagesSent.size, 5)
-    assertEquals(dummy.requested, 3)
+    assertEquals(dummy.requested, 2)
 
   }
 


### PR DESCRIPTION
 - change stream ingest to request more messages
   inside `onMessage` when queue size is greater
   than 0 and less than limit *before* we enqueue.
   Moreover, we only request more messages inside
   `messages` when queue size is equal to 0.

   The above approach avoids double requests for more
   messages when the prefetch limit is not reached.
   However, in the case of a fast consumer that keeps
   the queue drained we do not request for more on arrival,
   but on consumption.