### PR TITLE
Enable publishing standalone plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} scalafmtCheckAll test mimaReportBinaryIssues
 
       - name: Compress target directories
-        run: tar cf targets.tar plugin/target target codegen/target .protoc-gen/target runtime/target project/target
+        run: tar cf targets.tar plugin/target target .protoc-gen-fs2-grpc/target codegen/target runtime/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -99,12 +99,11 @@ lazy val runtime = project
     Test / parallelExecution := false
   )
 
-lazy val protocGen = protocGenProject("protoc-gen", codegen)
+lazy val protocGen = protocGenProject("protoc-gen-fs2-grpc", codegen)
   .settings(
     Compile / mainClass := Some(codegenFullName),
     scalaVersion := Scala212,
     githubWorkflowArtifactUpload := false,
-    publish / skip := true,
     mimaFailOnNoPrevious := false,
     mimaPreviousArtifacts := Set()
   )


### PR DESCRIPTION
Publishing protoc-gen enables non-sbt users to use fs2-grpc directly with protoc.

It looks like protoc-gen was being published up to commit 93c9da9d6346c73d3ebc325ed06cef4c6d5dfe05.