### PR TITLE
Publish standalone protoc plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} scalafmtCheckAll test mimaReportBinaryIssues
 
       - name: Compress target directories
-        run: tar cf targets.tar plugin/target target .protoc-gen-fs2-grpc/target codegen/target runtime/target project/target
+        run: tar cf targets.tar plugin/target target codegen/target runtime/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ inThisBuild(
 lazy val root = project
   .in(file("."))
   .enablePlugins(BuildInfoPlugin, NoPublishPlugin)
-  .aggregate(runtime, codegen, plugin, e2e)
+  .aggregate(runtime, codegen, plugin, e2e, protocGen.agg)
   .dependsOn(protocGen.agg)
 
 lazy val codegen = project
@@ -102,7 +102,10 @@ lazy val runtime = project
 lazy val protocGen = protocGenProject("protoc-gen-fs2-grpc", codegen)
   .settings(
     Compile / mainClass := Some(codegenFullName),
-    scalaVersion := Scala212,
+    githubWorkflowArtifactUpload := false,
+    scalaVersion := Scala212
+  )
+  .aggregateProjectSettings(
     githubWorkflowArtifactUpload := false,
     mimaFailOnNoPrevious := false,
     mimaPreviousArtifacts := Set()


### PR DESCRIPTION
#433 enabled the publish setting on the project level, but I haven't noticed that the project isn't within the root aggregate, so it didn't get publish through `sbt release`.