### PR TITLE
Publish protoc-gen only for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,6 +106,7 @@ lazy val protocGen = protocGenProject("protoc-gen-fs2-grpc", codegen)
     scalaVersion := Scala212
   )
   .aggregateProjectSettings(
+    crossScalaVersions := List(Scala212),
     githubWorkflowArtifactUpload := false,
     mimaFailOnNoPrevious := false,
     mimaPreviousArtifacts := Set()


### PR DESCRIPTION
Ensure the plugin built only once, to prevent duplicate builds at release time.