### PR TITLE
runtime: redo server unary to unary

### DIFF
--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCall.scala
@@ -57,10 +57,11 @@ private[server] class Fs2ServerCall[F[_], Request, Response](val call: ServerCal
 
 private[server] object Fs2ServerCall {
 
-  def apply[F[_]: Sync, Request, Response](
+  def make[F[_], Request, Response](
       call: ServerCall[Request, Response],
       options: ServerOptions
-  ): F[Fs2ServerCall[F, Request, Response]] = Sync[F].delay {
+  ): SyncIO[Fs2ServerCall[F, Request, Response]] = SyncIO.delay {
+
     val callOptions = options.callOptionsFn(ServerCallOptions.default)
 
     call.setMessageCompression(callOptions.messageCompression)
@@ -68,5 +69,11 @@ private[server] object Fs2ServerCall {
 
     new Fs2ServerCall[F, Request, Response](call)
   }
+
+  def apply[F[_]: Sync, Request, Response](
+      call: ServerCall[Request, Response],
+      options: ServerOptions
+  ): F[Fs2ServerCall[F, Request, Response]] =
+    make[F, Request, Response](call, options).to[F]
 
 }

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallHandler.scala
@@ -34,18 +34,8 @@ class Fs2ServerCallHandler[F[_]: Async] private (
 
   def unaryToUnaryCall[Request, Response](
       implementation: (Request, Metadata) => F[Response]
-<<<<<<< HEAD
-  ): ServerCallHandler[Request, Response] = new ServerCallHandler[Request, Response] {
-    def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-      val listener = dispatcher.unsafeRunSync(Fs2UnaryServerCallListener[F](call, dispatcher, options))
-      listener.unsafeUnaryResponse(new Metadata(), _ flatMap { request => implementation(request, headers) })
-      listener
-    }
-  }
-=======
   ): ServerCallHandler[Request, Response] =
     Fs2UnaryToUnaryHandler(implementation, dispatcher, options)
->>>>>>> 79eacbe (runtime: redo server unary to unary)
 
   def unaryToStreamingCall[Request, Response](
       implementation: (Request, Metadata) => Stream[F, Response]

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallHandler.scala
@@ -23,7 +23,6 @@ package fs2
 package grpc
 package server
 
-import cats.syntax.all._
 import cats.effect._
 import cats.effect.std.Dispatcher
 import io.grpc._
@@ -35,6 +34,7 @@ class Fs2ServerCallHandler[F[_]: Async] private (
 
   def unaryToUnaryCall[Request, Response](
       implementation: (Request, Metadata) => F[Response]
+<<<<<<< HEAD
   ): ServerCallHandler[Request, Response] = new ServerCallHandler[Request, Response] {
     def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
       val listener = dispatcher.unsafeRunSync(Fs2UnaryServerCallListener[F](call, dispatcher, options))
@@ -42,6 +42,10 @@ class Fs2ServerCallHandler[F[_]: Async] private (
       listener
     }
   }
+=======
+  ): ServerCallHandler[Request, Response] =
+    Fs2UnaryToUnaryHandler(implementation, dispatcher, options)
+>>>>>>> 79eacbe (runtime: redo server unary to unary)
 
   def unaryToStreamingCall[Request, Response](
       implementation: (Request, Metadata) => Stream[F, Response]

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
@@ -26,7 +26,7 @@ package server
 import cats.syntax.all._
 import cats.effect._
 import cats.effect.std.Dispatcher
-import io.grpc.{Metadata, Status, StatusException, StatusRuntimeException}
+import io.grpc.Metadata
 
 private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
 
@@ -35,19 +35,6 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   def call: Fs2ServerCall[F, Request, Response]
   def dispatcher: Dispatcher[F]
 
-  private def reportError(t: Throwable)(implicit F: Sync[F]): F[Unit] = {
-
-    t match {
-      case ex: StatusException =>
-        call.closeStream(ex.getStatus, Option(ex.getTrailers).getOrElse(new Metadata()))
-      case ex: StatusRuntimeException =>
-        call.closeStream(ex.getStatus, Option(ex.getTrailers).getOrElse(new Metadata()))
-      case ex =>
-        // TODO: Customize failure trailers?
-        call.closeStream(Status.INTERNAL.withDescription(ex.getMessage).withCause(ex), new Metadata())
-    }
-  }
-
   private def handleUnaryResponse(headers: Metadata, response: F[Response])(implicit F: Sync[F]): F[Unit] =
     call.sendHeaders(headers) *> call.request(1) *> response >>= call.sendMessage
 
@@ -55,14 +42,8 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
     call.sendHeaders(headers) *> call.request(1) *> response.evalMap(call.sendMessage).compile.drain
 
   private def unsafeRun(f: F[Unit])(implicit F: Async[F]): Unit = {
-    val bracketed = F.guaranteeCase(f) {
-      case Outcome.Succeeded(_) => call.closeStream(Status.OK, new Metadata())
-      case Outcome.Canceled() => call.closeStream(Status.CANCELLED, new Metadata())
-      case Outcome.Errored(t) => reportError(t)
-    }
-
     // Exceptions are reported by closing the call
-    dispatcher.unsafeRunAndForget(F.race(bracketed, isCancelled.get))
+    dispatcher.unsafeRunAndForget(F.race(call.handleOutcome(f), isCancelled.get))
   }
 
   def unsafeUnaryResponse(headers: Metadata, implementation: G[Request] => F[Response])(implicit

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2UnaryToUnaryHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2UnaryToUnaryHandler.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2
+package grpc
+package server
+
+import cats.syntax.all._
+import cats.effect._
+import cats.effect.std.Dispatcher
+import io.grpc._
+import io.grpc.ServerCall.Listener
+
+private[server] object Fs2UnaryToUnaryHandler {
+
+  def mkListener[F[_], I, O](
+      call: Fs2ServerCall[F, I, O],
+      headers: Metadata,
+      impl: (I, Metadata) => F[O],
+      isCancelled: Deferred[F, Unit],
+      dispatcher: Dispatcher[F]
+  )(implicit F: Async[F]): ServerCall.Listener[I] = new ServerCall.Listener[I] {
+
+    override def onCancel(): Unit = {
+      val action = isCancelled.complete(()).void
+      dispatcher.unsafeRunAndForget(action)
+    }
+
+    override def onMessage(message: I): Unit = {
+      val run = call.sendHeaders(headers) *> impl(message, headers) >>= call.sendMessage
+      val action = F.race(call.handleOutcome(run), isCancelled.get)
+      dispatcher.unsafeRunAndForget(action)
+    }
+
+  }
+
+  def apply[F[_]: Async, I, O](
+      impl: (I, Metadata) => F[O],
+      dispatcher: Dispatcher[F],
+      options: ServerOptions
+  ): ServerCallHandler[I, O] = new ServerCallHandler[I, O] {
+
+    def startCall(call: ServerCall[I, O], headers: Metadata): ServerCall.Listener[I] = {
+
+      val action: F[Listener[I]] = Deferred[F, Unit] >>= { isCancelled =>
+        Fs2ServerCall(call, options) >>= { fs2Call =>
+          val listener = mkListener(fs2Call, headers, impl, isCancelled, dispatcher)
+          fs2Call.request(1).as(listener)
+        }
+      }
+
+      dispatcher.unsafeRunSync(action)
+    }
+
+  }
+
+}


### PR DESCRIPTION
I see no point in dealing with a client that sends two messages in unary to unary calls. This makes the implementation a bit simpler in that we are not dealing with halfClose - call.handleOutcome closes the call as soon onMessage has executed.