### PR TITLE
Reimplement light server runtime

### DIFF
--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2ServerCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2ServerCall.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.server.internal
+
+import cats.effect._
+import cats.effect.std.Dispatcher
+import fs2._
+import fs2.grpc.server.ServerCallOptions
+import io.grpc._
+
+private[server] object Fs2ServerCall {
+  type Cancel = SyncIO[Unit]
+
+  def setup[I, O](
+      options: ServerCallOptions,
+      call: ServerCall[I, O]
+  ): SyncIO[Fs2ServerCall[I, O]] =
+    SyncIO {
+      call.setMessageCompression(options.messageCompression)
+      options.compressor.map(_.name).foreach(call.setCompression)
+      new Fs2ServerCall[I, O](call)
+    }
+}
+
+private[server] final class Fs2ServerCall[Request, Response](
+    call: ServerCall[Request, Response]
+) {
+
+  import Fs2ServerCall.Cancel
+
+  def stream[F[_]](response: Stream[F, Response], dispatcher: Dispatcher[F])(implicit F: Sync[F]): SyncIO[Cancel] =
+    run(
+      response.pull.peek1
+        .flatMap {
+          case Some((_, stream)) =>
+            Pull.suspend {
+              call.sendHeaders(new Metadata())
+              stream.map(call.sendMessage).pull.echo
+            }
+          case None => Pull.done
+        }
+        .stream
+        .compile
+        .drain,
+      dispatcher
+    )
+
+  def unary[F[_]](response: F[Response], dispatcher: Dispatcher[F])(implicit F: Sync[F]): SyncIO[Cancel] =
+    run(
+      F.map(response) { message =>
+        call.sendHeaders(new Metadata())
+        call.sendMessage(message)
+      },
+      dispatcher
+    )
+
+  def request(n: Int): SyncIO[Unit] =
+    SyncIO(call.request(n))
+
+  def close(status: Status, metadata: Metadata): SyncIO[Unit] =
+    SyncIO(call.close(status, metadata))
+
+  private def run[F[_]](completed: F[Unit], dispatcher: Dispatcher[F])(implicit F: Sync[F]): SyncIO[Cancel] = {
+    SyncIO {
+      val cancel = dispatcher.unsafeRunCancelable(F.guaranteeCase(completed) {
+        case Outcome.Succeeded(_) => close(Status.OK, new Metadata()).to[F]
+        case Outcome.Errored(e) => handleError(e).to[F]
+        case Outcome.Canceled() => close(Status.CANCELLED, new Metadata()).to[F]
+      })
+      SyncIO(cancel()).void
+    }
+  }
+
+  private def handleError(t: Throwable): SyncIO[Unit] = t match {
+    case ex: StatusException => close(ex.getStatus, Option(ex.getTrailers).getOrElse(new Metadata()))
+    case ex: StatusRuntimeException => close(ex.getStatus, Option(ex.getTrailers).getOrElse(new Metadata()))
+    case ex => close(Status.INTERNAL.withDescription(ex.getMessage).withCause(ex), new Metadata())
+  }
+}

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.server.internal
+
+import cats.effect.Ref
+import cats.effect.Sync
+import cats.effect.SyncIO
+import cats.effect.std.Dispatcher
+import fs2.grpc.server.ServerCallOptions
+import fs2.grpc.server.ServerOptions
+import io.grpc._
+
+private[server] object Fs2UnaryServerCallHandler {
+
+  import Fs2ServerCall.Cancel
+
+  sealed trait CallerState[A]
+  object CallerState {
+    def init[A](cb: A => SyncIO[Cancel]): SyncIO[Ref[SyncIO, CallerState[A]]] =
+      Ref[SyncIO].of[CallerState[A]](PendingMessage(cb))
+  }
+  case class PendingMessage[A](callback: A => SyncIO[Cancel]) extends CallerState[A] {
+    def receive(a: A): PendingHalfClose[A] = PendingHalfClose(callback, a)
+  }
+  case class PendingHalfClose[A](callback: A => SyncIO[Cancel], received: A) extends CallerState[A] {
+    def call(): SyncIO[Called[A]] = callback(received).map(Called.apply)
+  }
+  case class Called[A](cancel: Cancel) extends CallerState[A]
+  case class Cancelled[A]() extends CallerState[A]
+
+  private def mkListener[Request, Response](
+      call: Fs2ServerCall[Request, Response],
+      state: Ref[SyncIO, CallerState[Request]]
+  ): ServerCall.Listener[Request] =
+    new ServerCall.Listener[Request] {
+      override def onCancel(): Unit =
+        state.get
+          .flatMap {
+            case Called(cancel) => cancel >> state.set(Cancelled())
+            case _ => SyncIO.unit
+          }
+          .unsafeRunSync()
+
+      override def onMessage(message: Request): Unit =
+        state.get
+          .flatMap {
+            case s: PendingMessage[Request] =>
+              state.set(s.receive(message))
+            case _: PendingHalfClose[Request] =>
+              sendError(Status.INTERNAL.withDescription("Too many requests"))
+            case _ =>
+              SyncIO.unit
+          }
+          .unsafeRunSync()
+
+      override def onHalfClose(): Unit =
+        state.get
+          .flatMap {
+            case s: PendingHalfClose[Request] =>
+              s.call().flatMap(state.set)
+            case _: PendingMessage[Request] =>
+              sendError(Status.INTERNAL.withDescription("Half-closed without a request"))
+            case _ =>
+              SyncIO.unit
+          }
+          .unsafeRunSync()
+
+      private def sendError(status: Status): SyncIO[Unit] =
+        state.set(Cancelled()) >> call.close(status, new Metadata())
+    }
+
+  def unary[F[_]: Sync, Request, Response](
+      impl: (Request, Metadata) => F[Response],
+      options: ServerOptions,
+      dispatcher: Dispatcher[F]
+  ): ServerCallHandler[Request, Response] =
+    new ServerCallHandler[Request, Response] {
+      private val opt = options.callOptionsFn(ServerCallOptions.default)
+
+      def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] =
+        startCallSync(call, opt)(call => req => call.unary(impl(req, headers), dispatcher)).unsafeRunSync()
+    }
+
+  def stream[F[_]: Sync, Request, Response](
+      impl: (Request, Metadata) => fs2.Stream[F, Response],
+      options: ServerOptions,
+      dispatcher: Dispatcher[F]
+  ): ServerCallHandler[Request, Response] =
+    new ServerCallHandler[Request, Response] {
+      private val opt = options.callOptionsFn(ServerCallOptions.default)
+
+      def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] =
+        startCallSync(call, opt)(call => req => call.stream(impl(req, headers), dispatcher)).unsafeRunSync()
+    }
+
+  private def startCallSync[F[_], Request, Response](
+      call: ServerCall[Request, Response],
+      options: ServerCallOptions
+  )(f: Fs2ServerCall[Request, Response] => Request => SyncIO[Cancel]): SyncIO[ServerCall.Listener[Request]] = {
+    for {
+      call <- Fs2ServerCall.setup(options, call)
+      // We expect only 1 request, but we ask for 2 requests here so that if a misbehaving client
+      // sends more than 1 requests, ServerCall will catch it.
+      _ <- call.request(2)
+      state <- CallerState.init(f(call))
+    } yield mkListener[Request, Response](call, state)
+  }
+}

--- a/runtime/src/test/scala/fs2/grpc/server/ServerSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/ServerSuite.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 import cats.effect._
 import cats.effect.std.Dispatcher
 import cats.effect.testkit.TestContext
-import fs2._
+import fs2.grpc.server.internal.Fs2UnaryServerCallHandler
 import io.grpc._
 
 class ServerSuite extends Fs2GrpcSuite {
@@ -42,9 +42,9 @@ class ServerSuite extends Fs2GrpcSuite {
       options: ServerOptions = ServerOptions.default
   ): (TestContext, Dispatcher[IO]) => Unit = { (tc, d) =>
     val dummy = new DummyServerCall
+    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length), options, d)
+    val listener = handler.startCall(dummy, new Metadata())
 
-    val listener = Fs2UnaryServerCallListener[IO](dummy, d, options).unsafeRunSync()
-    listener.unsafeUnaryResponse(new Metadata(), _.map(_.length))
     listener.onMessage("123")
     listener.onHalfClose()
     tc.tick()
@@ -57,20 +57,33 @@ class ServerSuite extends Fs2GrpcSuite {
 
   runTest("cancellation for unaryToUnary") { (tc, d) =>
     val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO](dummy, d, ServerOptions.default).unsafeRunSync()
-
-    listener.unsafeUnaryResponse(new Metadata(), _.map(_.length))
+    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length), ServerOptions.default, d)
+    val listener = handler.startCall(dummy, new Metadata())
 
     listener.onCancel()
     tc.tick()
 
-    val cancelled = listener.isCancelled.get.unsafeToFuture()
+    assertEquals(dummy.currentStatus, None)
+    assertEquals(dummy.messages.length, 0)
+  }
+
+  runTest("cancellation on the fly for unaryToUnary") { (tc, d) =>
+    val dummy = new DummyServerCall
+    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int](
+      (req, _) => IO(req.length).delayBy(10.seconds),
+      ServerOptions.default,
+      d
+    )
+    val listener = handler.startCall(dummy, new Metadata())
+
+    listener.onMessage("123")
+    listener.onHalfClose()
+    tc.tick()
+    listener.onCancel()
     tc.tick()
 
-    IO.sleep(50.millis).unsafeRunSync()
-
-    assertEquals(cancelled.isCompleted, true)
-
+    assertEquals(dummy.currentStatus.map(_.getCode), Some(Status.Code.CANCELLED))
+    assertEquals(dummy.messages.length, 0)
   }
 
   runTest("multiple messages to unaryToUnary")(multipleUnaryToUnary())
@@ -80,21 +93,31 @@ class ServerSuite extends Fs2GrpcSuite {
       options: ServerOptions = ServerOptions.default
   ): (TestContext, Dispatcher[IO]) => Unit = { (tc, d) =>
     val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO](dummy, d, options).unsafeRunSync()
+    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length), options, d)
+    val listener = handler.startCall(dummy, new Metadata())
 
-    listener.unsafeUnaryResponse(new Metadata(), _.map(_.length))
     listener.onMessage("123")
+    listener.onMessage("456")
+    listener.onHalfClose()
+    tc.tick()
 
-    intercept[StatusRuntimeException] {
-      listener.onMessage("456")
-    }
+    assertEquals(dummy.currentStatus.map(_.getCode), Some(Status.Code.INTERNAL))
+  }
+
+  runTest("no messages to unaryToUnary")(noMessageUnaryToUnary())
+  runTest("no messages to unaryToUnary with compression")(noMessageUnaryToUnary(compressionOps))
+
+  private def noMessageUnaryToUnary(
+      options: ServerOptions = ServerOptions.default
+  ): (TestContext, Dispatcher[IO]) => Unit = { (tc, d) =>
+    val dummy = new DummyServerCall
+    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length), options, d)
+    val listener = handler.startCall(dummy, new Metadata())
 
     listener.onHalfClose()
-    tc.tickAll()
+    tc.tick()
 
-    assertEquals(dummy.currentStatus.isDefined, true)
-    assertEquals(dummy.currentStatus.get.isOk, true, "Current status true because stream completed successfully")
-
+    assertEquals(dummy.currentStatus.map(_.getCode), Some(Status.Code.INTERNAL))
   }
 
   runTest0("resource awaits termination of server") { (tc, r, _) =>
@@ -115,9 +138,10 @@ class ServerSuite extends Fs2GrpcSuite {
       options: ServerOptions = ServerOptions.default
   ): (TestContext, Dispatcher[IO]) => Unit = { (tc, d) =>
     val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO][String, Int](dummy, d, options).unsafeRunSync()
+    val handler =
+      Fs2UnaryServerCallHandler.stream[IO, String, Int]((s, _) => Stream(s).map(_.length).repeat.take(5), options, d)
+    val listener = handler.startCall(dummy, new Metadata())
 
-    listener.unsafeStreamResponse(new Metadata(), s => Stream.eval(s).map(_.length).repeat.take(5))
     listener.onMessage("123")
     listener.onHalfClose()
     tc.tick()
@@ -130,9 +154,11 @@ class ServerSuite extends Fs2GrpcSuite {
 
   runTest("zero messages to streamingToStreaming") { (tc, d) =>
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, d, ServerOptions.default).unsafeRunSync()
 
-    listener.unsafeStreamResponse(new Metadata(), _ => Stream.emit(3).repeat.take(5))
+    val handler = Fs2ServerCallHandler[IO](d, ServerOptions.default)
+      .streamingToStreamingCall[String, Int]((_, _) => Stream.emit(3).repeat.take(5))
+    val listener = handler.startCall(dummy, new Metadata())
+
     listener.onHalfClose()
     tc.tick()
 
@@ -144,15 +170,17 @@ class ServerSuite extends Fs2GrpcSuite {
 
   runTest("cancellation for streamingToStreaming") { (tc, d) =>
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, d, ServerOptions.default).unsafeRunSync()
+    val handler = Fs2ServerCallHandler[IO](d, ServerOptions.default)
+      .streamingToStreamingCall[String, Int]((_, _) =>
+        Stream.emit(3).repeat.take(5).zipLeft(Stream.awakeDelay[IO](1.seconds))
+      )
+    val listener = handler.startCall(dummy, new Metadata())
 
-    listener.unsafeStreamResponse(new Metadata(), _ => Stream.emit(3).repeat.take(5))
+    tc.tick()
     listener.onCancel()
+    tc.tick()
 
-    val cancelled = listener.isCancelled.get.unsafeToFuture()
-    tc.tickAll()
-
-    assertEquals(cancelled.isCompleted, true)
+    assertEquals(dummy.currentStatus.map(_.getCode), Some(Status.Code.CANCELLED))
   }
 
   runTest("messages to streamingToStreaming")(multipleStreamingToStreaming())
@@ -162,9 +190,10 @@ class ServerSuite extends Fs2GrpcSuite {
       options: ServerOptions = ServerOptions.default
   ): (TestContext, Dispatcher[IO]) => Unit = { (tc, d) =>
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, d, options).unsafeRunSync()
+    val handler = Fs2ServerCallHandler[IO](d, options)
+      .streamingToStreamingCall[String, Int]((req, _) => req.map(_.length).intersperse(0))
+    val listener = handler.startCall(dummy, new Metadata())
 
-    listener.unsafeStreamResponse(new Metadata(), _.map(_.length).intersperse(0))
     listener.onMessage("a")
     listener.onMessage("ab")
     listener.onHalfClose()
@@ -179,13 +208,16 @@ class ServerSuite extends Fs2GrpcSuite {
   runTest("messages to streamingToStreaming with error") { (tc, d) =>
     val dummy = new DummyServerCall
     val error = new RuntimeException("hello")
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, d, ServerOptions.default).unsafeRunSync()
 
-    listener.unsafeStreamResponse(new Metadata(), _.map(_.length) ++ Stream.emit(0) ++ Stream.raiseError[IO](error))
+    val handler = Fs2ServerCallHandler[IO](d, ServerOptions.default)
+      .streamingToStreamingCall[String, Int]((req, _) =>
+        req.map(_.length) ++ Stream.emit(0) ++ Stream.raiseError[IO](error)
+      )
+    val listener = handler.startCall(dummy, new Metadata())
+
     listener.onMessage("a")
     listener.onMessage("ab")
     listener.onHalfClose()
-    listener.onMessage("abc")
     tc.tick()
 
     assertEquals(dummy.messages.length, 3)
@@ -204,9 +236,11 @@ class ServerSuite extends Fs2GrpcSuite {
       _.compile.foldMonoid.map(_.length)
 
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, d, so).unsafeRunSync()
 
-    listener.unsafeUnaryResponse(new Metadata(), implementation)
+    val handler = Fs2ServerCallHandler[IO](d, so)
+      .streamingToUnaryCall[String, Int]((req, _) => implementation(req))
+    val listener = handler.startCall(dummy, new Metadata())
+
     listener.onMessage("ab")
     listener.onMessage("abc")
     listener.onHalfClose()


### PR DESCRIPTION
This runtime call to 1 unsafeRun* / RPC.

This PR come from https://github.com/typelevel/fs2-grpc/pull/493

Background https://github.com/typelevel/fs2-grpc/issues/386