### PR TITLE
implement non-blocking stream server handler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,8 @@ inThisBuild(
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.client.StreamIngest.create"),
       // deleted private classes
       ProblemFilters.exclude[MissingClassProblem]("fs2.grpc.client.Fs2UnaryClientCallListener*"),
-      ProblemFilters.exclude[MissingClassProblem]("fs2.grpc.server.Fs2UnaryServerCallListener*")
+      ProblemFilters.exclude[MissingClassProblem]("fs2.grpc.server.Fs2UnaryServerCallListener*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.server.internal.*")
     )
   )
 )

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2ServerCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2ServerCall.scala
@@ -73,6 +73,12 @@ private[server] final class Fs2ServerCall[Request, Response](
       dispatcher
     )
 
+  def requestOnPull[F[_]]: Pipe[F, Request, Request] =
+    _.mapChunks { chunk =>
+      call.request(chunk.size)
+      chunk
+    }
+
   def request(n: Int): SyncIO[Unit] =
     SyncIO(call.request(n))
 

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2StreamServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2StreamServerCallHandler.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.server.internal
+
+import cats.effect.Async
+import cats.effect.SyncIO
+import fs2._
+import fs2.grpc.server.ServerCallOptions
+import fs2.grpc.server.ServerOptions
+import fs2.grpc.server.internal.Fs2ServerCall.Cancel
+import io.grpc.ServerCall
+import io.grpc._
+
+object Fs2StreamServerCallHandler {
+
+  private def mkListener[Request](
+      channel: OneShotChannel[Request],
+      cancel: Cancel
+  ): ServerCall.Listener[Request] =
+    new ServerCall.Listener[Request] {
+      override def onCancel(): Unit =
+        cancel.unsafeRunSync()
+
+      override def onMessage(message: Request): Unit =
+        channel.send(message).unsafeRunSync()
+
+      override def onHalfClose(): Unit =
+        channel.close().unsafeRunSync()
+    }
+
+  def mkHandler[F[_]: Async, G[_], Request, Response](
+      impl: (Stream[F, Request], Metadata) => G[Response],
+      options: ServerOptions
+  )(start: (Fs2ServerCall[Request, Response], G[Response]) => SyncIO[Cancel]): ServerCallHandler[Request, Response] =
+    new ServerCallHandler[Request, Response] {
+      private val opt = options.callOptionsFn(ServerCallOptions.default)
+
+      def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
+        for {
+          call <- Fs2ServerCall.setup(opt, call)
+          _ <- call.request(1) // prefetch size
+          channel <- OneShotChannel.empty[Request]
+          cancel <- start(call, impl(channel.stream.through(call.requestOnPull), headers))
+        } yield mkListener(channel, cancel)
+      }.unsafeRunSync()
+    }
+}

--- a/runtime/src/main/scala/fs2/grpc/server/internal/OneShotChannel.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/OneShotChannel.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.server.internal
+
+import cats.effect._
+import cats.syntax.functor._
+import fs2._
+import fs2.grpc.server.internal.OneShotChannel.State
+import scala.collection.immutable.Queue
+
+private[server] final class OneShotChannel[A](val state: Ref[SyncIO, State[A]]) extends AnyVal {
+
+  import State._
+
+  /** Send message to stream.
+    */
+  def send(a: A): SyncIO[Unit] =
+    state
+      .modify {
+        case open: Open[A] => (open.append(a), SyncIO.unit)
+        case s: Suspended[A] => (State.consumed, s.resume(State.open(a)))
+        case closed => (closed, SyncIO.unit)
+      }
+      .flatMap(identity)
+
+  /** Close stream.
+    */
+  def close(): SyncIO[Unit] =
+    state
+      .modify {
+        case open: Open[A] => (open.close(), SyncIO.unit)
+        case s: Suspended[A] => (State.done, s.resume(State.done))
+        case closed => (closed, SyncIO.unit)
+      }
+      .flatMap(identity)
+
+  import fs2._
+
+  /** This method can be called at most once
+    */
+  def stream[F[_]](implicit F: Async[F]): Stream[F, A] = {
+    def go(): Pull[F, A, Unit] =
+      Pull
+        .eval(state.getAndSet(State.consumed).to[F])
+        .flatMap {
+          case Consumed =>
+            Pull.eval(F.async[State[A]] { cb =>
+              val next = new Suspended[A](s => cb(Right(s)))
+              state
+                .modify {
+                  case Consumed => (next, None)
+                  case other => (State.consumed, Some(other))
+                }
+                .to[F]
+                .map {
+                  case Some(received) =>
+                    cb(Right(received))
+                    None
+                  case None =>
+                    Some(state.set(State.consumed).to[F])
+                }
+            })
+          case other => Pull.pure(other)
+        }
+        .flatMap {
+          case open: Open[A] => open.toPull >> go()
+          case other => other.toPull
+        }
+
+    go().stream
+  }
+}
+
+private[server] object OneShotChannel {
+  def empty[A]: SyncIO[OneShotChannel[A]] =
+    Ref[SyncIO].of[State[A]](State.consumed).map(new OneShotChannel[A](_))
+
+  sealed trait State[A] {
+    def toPull[F[_]: Sync]: Pull[F, A, Unit]
+  }
+
+  object State {
+    class UnexpectedState extends RuntimeException
+    private[OneShotChannel] val Consumed: State[Nothing] = new Open(Queue.empty)
+    def consumed[A]: State[A] = Consumed.asInstanceOf[State[A]]
+
+    def done[A]: State[A] = new Closed(Queue.empty)
+
+    def open[A](a: A): Open[A] = new Open(Queue(a))
+
+    class Open[A](queue: Queue[A]) extends State[A] {
+      def append(a: A): Open[A] = new Open(queue.enqueue(a))
+
+      def toPull[F[_]: Sync]: Pull[F, A, Unit] = Pull.output(Chunk.queue(queue))
+
+      def close(): State[A] = new Closed(queue)
+    }
+
+    class Closed[A](queue: Queue[A]) extends State[A] {
+      def toPull[F[_]: Sync]: Pull[F, A, Unit] = Pull.output(Chunk.queue(queue))
+    }
+
+    class Suspended[A](f: State[A] => Unit) extends State[A] {
+      def resume(state: State[A]): SyncIO[Unit] = SyncIO(f(state))
+
+      def toPull[F[_]: Sync]: Pull[F, A, Unit] = Pull.raiseError(new UnexpectedState) // never happened
+    }
+  }
+}

--- a/runtime/src/test/scala/fs2/grpc/client/ClientSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/client/ClientSuite.scala
@@ -95,6 +95,7 @@ class ClientSuite extends Fs2GrpcSuite {
     assertEquals(dummy.messagesSent.size, 1)
     assertEquals(dummy.requested, 2)
 
+    Thread.sleep(10)
   }
 
   runTest0("error response to unaryToUnary") { (tc, io, d) =>

--- a/runtime/src/test/scala/fs2/grpc/server/DummyServerCall.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/DummyServerCall.scala
@@ -30,6 +30,7 @@ import scala.collection.mutable.ArrayBuffer
 class DummyServerCall extends ServerCall[String, Int] {
   val messages: ArrayBuffer[Int] = ArrayBuffer[Int]()
   var currentStatus: Option[Status] = None
+  var explicitCompressor: Option[String] = None
 
   override def request(numMessages: Int): Unit = ()
   override def sendMessage(message: Int): Unit = {
@@ -43,5 +44,10 @@ class DummyServerCall extends ServerCall[String, Int] {
   override def close(status: Status, trailers: Metadata): Unit = {
     currentStatus = Some(status)
   }
+
+  override def setCompression(compressor: String): Unit = {
+    explicitCompressor = Some(compressor)
+  }
+
   override def isCancelled: Boolean = false
 }

--- a/runtime/src/test/scala/fs2/grpc/server/OneShotChannelSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/OneShotChannelSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.server
+
+import cats.effect._
+import cats.effect.testkit.TestControl
+import fs2._
+import fs2.grpc.server.internal.OneShotChannel
+import munit.CatsEffectFunFixtures
+import munit.CatsEffectSuite
+import scala.concurrent.duration._
+
+class OneShotChannelSuite extends CatsEffectSuite with CatsEffectFunFixtures {
+
+  def run(size: Int, producerDelay: Int, consumerDelay: Int): IO[Unit] = {
+    for {
+      ch <- OneShotChannel.empty[Int].to[IO]
+      chunkN <- Ref[IO].of(0)
+      stream <- ch
+        .stream[IO]
+        .chunks
+        .evalTap(_ => chunkN.update(_ + 1))
+        .unchunks
+        .zipLeft(Stream.awakeDelay[IO](consumerDelay.seconds))
+        .compile
+        .toList
+        .start
+      _ <- Stream
+        .range(0, size)
+        .evalMap(c => ch.send(c).to[IO])
+        .append(Stream.exec(ch.close().to[IO]))
+        .zipLeft(Stream.awakeDelay[IO](producerDelay.seconds))
+        .compile
+        .drain
+      stream <- stream.joinWithNever
+      chunkN <- chunkN.get
+    } yield {
+      assertEquals(stream, Stream.range(0, size).toList)
+      if (consumerDelay > producerDelay) {
+        assert(clue(chunkN) < clue(size))
+      } else {
+        assertEquals(chunkN, size)
+      }
+    }
+  }
+
+  test("basic") {
+    TestControl.executeEmbed(
+      run(0, 1, 1) >>
+        run(1, 1, 1) >>
+        run(2, 1, 1) >>
+        run(8, 1, 1)
+    )
+  }
+  test("slow producer") {
+    TestControl.executeEmbed(
+      run(8, 2, 1) >>
+        run(16, 4, 3)
+    )
+  }
+  test("slow consumer") {
+    TestControl.executeEmbed(
+      run(8, 1, 2) >>
+        run(16, 3, 4)
+    )
+  }
+}


### PR DESCRIPTION
## What this PR do
- Eliminate blocking from stream server runtime.
- align unary server runtime I/F
- fix flaky ServerSuit

## ClientStreaming Benchmark
method implement 
```scala
request.compile.last.map(_.fold(HelloReply())(r => HelloReply(r.request)))
```

Request 100 messages with `ghq --cpu=4 -z 60s --connections=5 ...`

### #503 
```
actual cpu used: 1.0core
Summary:
  Count:	39264
  Total:	60.00 s
  Slowest:	385.42 ms
  Fastest:	2.80 ms
  Average:	74.86 ms
  Requests/sec:	654.39
```

### main
```
actual cpu used: 1.0core
Summary:
  Count:	11280
  Total:	60.00 s
  Slowest:	1.09 s
  Fastest:	7.85 ms
  Average:	265.53 ms
  Requests/sec:	188.00
```