### PR TITLE
add lightweight toUnary client runtime

### DIFF
--- a/runtime/src/main/scala/fs2/grpc/client/internal/Fs2UnaryCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/internal/Fs2UnaryCallHandler.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.client.internal
+
+import cats.effect.Sync
+import cats.effect.SyncIO
+import cats.effect.syntax.all._
+import cats.effect.kernel.Async
+import cats.effect.kernel.Ref
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+import fs2._
+import fs2.grpc.client.ClientOptions
+import io.grpc._
+
+object Fs2UnaryCallHandler {
+  sealed trait ReceiveState[R]
+
+  object ReceiveState {
+    def init[F[_]: Sync, R](
+        callback: Either[Throwable, R] => Unit,
+        pf: PartialFunction[StatusRuntimeException, Exception]
+    ): F[Ref[SyncIO, ReceiveState[R]]] =
+      Ref.in(new PendingMessage[R]({
+        case r: Right[Throwable, R] => callback(r)
+        case Left(e: StatusRuntimeException) => callback(Left(pf.lift(e).getOrElse(e)))
+        case l: Left[Throwable, R] => callback(l)
+      }))
+  }
+
+  class PendingMessage[R](callback: Either[Throwable, R] => Unit) extends ReceiveState[R] {
+    def receive(message: R): PendingHalfClose[R] = new PendingHalfClose(callback, message)
+
+    def sendError(error: Throwable): SyncIO[ReceiveState[R]] =
+      SyncIO(callback(Left(error))).as(new Done[R])
+  }
+
+  class PendingHalfClose[R](callback: Either[Throwable, R] => Unit, message: R) extends ReceiveState[R] {
+    def sendError(error: Throwable): SyncIO[ReceiveState[R]] =
+      SyncIO(callback(Left(error))).as(new Done[R])
+
+    def done(): SyncIO[ReceiveState[R]] = SyncIO(callback(Right(message))).as(new Done[R])
+  }
+
+  class Done[R] extends ReceiveState[R]
+
+  private def mkListener[Response](
+      state: Ref[SyncIO, ReceiveState[Response]]
+  ): ClientCall.Listener[Response] =
+    new ClientCall.Listener[Response] {
+      override def onMessage(message: Response): Unit =
+        state.get
+          .flatMap {
+            case expected: PendingMessage[Response] =>
+              state.set(expected.receive(message))
+            case current: PendingHalfClose[Response] =>
+              current
+                .sendError(
+                  Status.INTERNAL
+                    .withDescription("More than one value received for unary call")
+                    .asRuntimeException()
+                )
+                .flatMap(state.set)
+            case _ => SyncIO.unit
+          }
+          .unsafeRunSync()
+
+      override def onClose(status: Status, trailers: Metadata): Unit = {
+        if (status.isOk) {
+          state.get.flatMap {
+            case expected: PendingHalfClose[Response] => expected.done().flatMap(state.set)
+            case current: PendingMessage[Response] =>
+              current
+                .sendError(
+                  Status.INTERNAL
+                    .withDescription("No value received for unary call")
+                    .asRuntimeException(trailers)
+                )
+                .flatMap(state.set)
+            case _ => SyncIO.unit
+          }
+        } else {
+          state.get.flatMap {
+            case current: PendingHalfClose[Response] =>
+              current.sendError(status.asRuntimeException(trailers)).flatMap(state.set)
+            case current: PendingMessage[Response] =>
+              current.sendError(status.asRuntimeException(trailers)).flatMap(state.set)
+            case _ => SyncIO.unit
+          }
+        }
+      }.unsafeRunSync()
+    }
+
+  def unary[F[_], Request, Response](
+      call: ClientCall[Request, Response],
+      options: ClientOptions,
+      message: Request,
+      headers: Metadata
+  )(implicit F: Async[F]): F[Response] = F.async[Response] { cb =>
+    ReceiveState.init(cb, options.errorAdapter).map { state =>
+      call.start(mkListener[Response](state), headers)
+      // Initially ask for two responses from flow-control so that if a misbehaving server
+      // sends more than one responses, we can catch it and fail it in the listener.
+      call.request(2)
+      call.sendMessage(message)
+      call.halfClose()
+      Some(onCancel(call))
+    }
+  }
+
+  def stream[F[_], Request, Response](
+      call: ClientCall[Request, Response],
+      options: ClientOptions,
+      message: Stream[F, Request],
+      headers: Metadata
+  )(implicit F: Async[F]): F[Response] = F.async[Response] { cb =>
+    ReceiveState.init(cb, options.errorAdapter).flatMap { state =>
+      call.start(mkListener[Response](state), headers)
+      // Initially ask for two responses from flow-control so that if a misbehaving server
+      // sends more than one responses, we can catch it and fail it in the listener.
+      call.request(2)
+      message
+        .map(call.sendMessage)
+        .onFinalize(F.delay(call.halfClose()))
+        .compile
+        .drain
+        .start
+        .map(fiber => Some(fiber.cancel >> onCancel(call)))
+    }
+  }
+
+  private def onCancel[F[_]](call: ClientCall[_, _])(implicit F: Async[F]): F[Unit] =
+    F.delay(call.cancel("call was cancelled", null))
+
+}

--- a/runtime/src/test/scala/fs2/grpc/client/ClientSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/client/ClientSuite.scala
@@ -53,7 +53,7 @@ class ClientSuite extends Fs2GrpcSuite {
     tc.tick()
     assertEquals(result.value, Some(Success(5)))
     assertEquals(dummy.messagesSent.size, 1)
-    assertEquals(dummy.requested, 1)
+    assertEquals(dummy.requested, 2)
 
   }
 
@@ -93,7 +93,7 @@ class ClientSuite extends Fs2GrpcSuite {
     assert(result.value.get.isFailure)
     assert(result.value.get.failed.get.isInstanceOf[StatusRuntimeException])
     assertEquals(dummy.messagesSent.size, 1)
-    assertEquals(dummy.requested, 1)
+    assertEquals(dummy.requested, 2)
 
   }
 
@@ -118,7 +118,7 @@ class ClientSuite extends Fs2GrpcSuite {
       Status.INTERNAL
     )
     assertEquals(dummy.messagesSent.size, 1)
-    assertEquals(dummy.requested, 1)
+    assertEquals(dummy.requested, 2)
 
   }
 
@@ -142,7 +142,7 @@ class ClientSuite extends Fs2GrpcSuite {
     tc.tick()
     assertEquals(result.value, Some(Success(5)))
     assertEquals(dummy.messagesSent.size, 3)
-    assertEquals(dummy.requested, 1)
+    assertEquals(dummy.requested, 2)
 
   }
 
@@ -166,7 +166,7 @@ class ClientSuite extends Fs2GrpcSuite {
     tc.tick()
     assertEquals(result.value, Some(Success(5)))
     assertEquals(dummy.messagesSent.size, 0)
-    assertEquals(dummy.requested, 1)
+    assertEquals(dummy.requested, 2)
 
   }
 

--- a/runtime/src/test/scala/fs2/grpc/client/DummyClientCall.scala
+++ b/runtime/src/test/scala/fs2/grpc/client/DummyClientCall.scala
@@ -31,6 +31,7 @@ class DummyClientCall extends ClientCall[String, Int] {
   val messagesSent: ArrayBuffer[String] = ArrayBuffer[String]()
   var listener: Option[ClientCall.Listener[Int]] = None
   var cancelled: Option[(String, Throwable)] = None
+  var halfClosed = false
 
   override def start(responseListener: ClientCall.Listener[Int], headers: Metadata): Unit =
     listener = Some(responseListener)
@@ -40,7 +41,8 @@ class DummyClientCall extends ClientCall[String, Int] {
   override def cancel(message: String, cause: Throwable): Unit =
     cancelled = Some((message, cause))
 
-  override def halfClose(): Unit = ()
+  override def halfClose(): Unit =
+    halfClosed = true
 
   override def sendMessage(message: String): Unit = {
     messagesSent += message


### PR DESCRIPTION
# What this PR do?
This PR eliminate using Dispatcher[F] from toUnary client runtime.

# Benchmark
50 pararell request in 30sec with 2core from MBP to other server
```
IO.defer(client.sayHello(msg, new Metadata()))
  .foreverM
  .parReplicateA(50)
  .timeout(30.seconds)
```

### This PR
```
count: 885665 in 30sec
rps: 29522
avg: 1692625 nanoseconds
min: 188387 nanoseconds
25%: 945601 nanoseconds
50%: 1128934 nanoseconds
75%: 1474530 nanoseconds
95%: 2677452 nanoseconds
99%: 10760997 nanoseconds
max: 277718411 nanoseconds
```
### main
```
count: 420181 in 30sec
rps: 14006
avg: 3566715 nanoseconds
min: 413625 nanoseconds
25%: 1161330 nanoseconds
50%: 1448318 nanoseconds
75%: 1968762 nanoseconds
95%: 3918554 nanoseconds
99%: 60713069 nanoseconds
max: 227741517 nanoseconds
```
