### PR TITLE
build: add explicit sbt-protoc version to plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,6 @@ addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.9")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")
 
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6") // Because sbt-protoc-gen-project brings in 1.0.4
 addSbtPlugin("com.thesamet" % "sbt-protoc-gen-project" % "0.1.8")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.10"


### PR DESCRIPTION
- add explicit version of sbt-protoc to plugins to get functionality that detects Apple Silicon.