### PR TITLE
[v0.x] Remove unbounded queue on server-side stream reception

### DIFF
--- a/java-runtime/src/main/scala/Readiness.scala
+++ b/java-runtime/src/main/scala/Readiness.scala
@@ -1,0 +1,50 @@
+package org.lyranthe.fs2_grpc
+package java_runtime
+package shared
+
+import cats.Applicative
+import cats.effect.Concurrent
+import cats.effect.concurrent.{Deferred, Ref}
+import cats.implicits._
+
+// Readiness implements respect for GRPC's backpressure on the sender
+// - i.e. it delays sending into a channel if that channel
+// is full.
+private [java_runtime] class ReadinessImpl[F[_]](
+  waiting: Ref[F, Option[Deferred[F, Unit]]]
+)(implicit F: Concurrent[F]) extends Readiness[F] {
+  def signal: F[Unit] = {
+    waiting.getAndSet(None).flatMap {
+      case None => F.unit
+      case Some(wake) => wake.complete(())
+    }
+  }
+
+  def whenReady(isReady: F[Boolean], action: F[Unit]): F[Unit] = {
+    isReady.ifM(action, {
+      Deferred[F, Unit].flatMap { wakeup =>
+        waiting.set(wakeup.some) *>
+          isReady.ifM(signal, F.unit) *> // trigger manually in case onReady was invoked before we installed wakeup
+          wakeup.get *>
+          action
+      }
+    })
+  }
+}
+
+private [java_runtime] trait Readiness[F[_]] {
+  def signal: F[Unit]
+
+  def whenReady(isReady: F[Boolean], action: F[Unit]): F[Unit]
+}
+
+private [java_runtime] object Readiness {
+  def apply[F[_]](implicit F: Concurrent[F]): F[Readiness[F]] =
+    Ref[F].of(Option.empty[Deferred[F, Unit]]).map(new ReadinessImpl(_))
+
+  def noop[F[_]](implicit F: Applicative[F]): Readiness[F] = new Readiness[F] {
+    override def signal: F[Unit] = F.unit
+
+    override def whenReady(isReady: F[Boolean], action: F[Unit]): F[Unit] = action
+  }
+}

--- a/java-runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
+++ b/java-runtime/src/main/scala/client/Fs2StreamClientCallListener.scala
@@ -8,8 +8,10 @@ import fs2.Stream
 import io.grpc.{ClientCall, Metadata, Status}
 
 private[client] class Fs2StreamClientCallListener[F[_]: Effect, Response](
-    ingest: StreamIngest[F, Response]
+    ingest: StreamIngest[F, Response],
+    signalReadiness: F[Unit],
 ) extends ClientCall.Listener[Response] {
+  override def onReady(): Unit = signalReadiness.unsafeRun()
 
   override def onMessage(message: Response): Unit =
     ingest.onMessage(message).unsafeRun()
@@ -25,10 +27,11 @@ private[client] object Fs2StreamClientCallListener {
 
   def apply[F[_], Response](
       request: Int => F[Unit],
+      signalReadiness: F[Unit],
       prefetchN: Int
   )(implicit F: ConcurrentEffect[F]): F[Fs2StreamClientCallListener[F, Response]] =
-    StreamIngest[F, Response](request, prefetchN).map(
-      new Fs2StreamClientCallListener[F, Response](_)
+    StreamIngest[F, Response](request, prefetchN).map(streamIngest =>
+      new Fs2StreamClientCallListener[F, Response](streamIngest, signalReadiness)
     )
 
 }

--- a/java-runtime/src/main/scala/client/StreamIngest.scala
+++ b/java-runtime/src/main/scala/client/StreamIngest.scala
@@ -1,19 +1,19 @@
 package org.lyranthe.fs2_grpc
 package java_runtime
-package client
+package client // TODO shared?
 
 import cats.syntax.all._
 import cats.effect._
 import fs2.Stream
 import fs2.concurrent.InspectableQueue
 
-private[client] trait StreamIngest[F[_], T] {
+private[java_runtime] trait StreamIngest[F[_], T] {
   def onMessage(msg: T): F[Unit]
   def onClose(status: GrpcStatus): F[Unit]
   def messages: Stream[F, T]
 }
 
-private[client] object StreamIngest {
+private[java_runtime] object StreamIngest {
 
   def apply[F[_]: ConcurrentEffect, T](
       request: Int => F[Unit],

--- a/java-runtime/src/main/scala/server/Fs2ServerCall.scala
+++ b/java-runtime/src/main/scala/server/Fs2ServerCall.scala
@@ -5,6 +5,7 @@ package server
 import cats.effect._
 import cats.syntax.functor._
 import io.grpc._
+import org.lyranthe.fs2_grpc.java_runtime.shared.Readiness
 
 // TODO: Add attributes, compression, message compression.
 private[server] class Fs2ServerCall[F[_], Request, Response](val call: ServerCall[Request, Response]) extends AnyVal {
@@ -14,7 +15,12 @@ private[server] class Fs2ServerCall[F[_], Request, Response](val call: ServerCal
   def closeStream(status: Status, trailers: Metadata)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.close(status, trailers))
 
-  def sendMessage(message: Response)(implicit F: Sync[F]): F[Unit] =
+  private def isReady(implicit F: Sync[F]): F[Boolean] = F.delay(call.isReady)
+
+  def sendMessageWhenReady(readiness: Readiness[F])(implicit F: Sync[F]): Response => F[Unit] =
+    message => readiness.whenReady(isReady, sendMessageImmediately(message))
+
+  def sendMessageImmediately(message: Response)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.sendMessage(message))
 
   def request(numMessages: Int)(implicit F: Sync[F]): F[Unit] =

--- a/java-runtime/src/main/scala/server/Fs2ServerCallHandler.scala
+++ b/java-runtime/src/main/scala/server/Fs2ServerCallHandler.scala
@@ -6,6 +6,7 @@ import cats.effect._
 import cats.implicits._
 import fs2._
 import io.grpc._
+import org.lyranthe.fs2_grpc.java_runtime.shared.Readiness
 
 class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
 
@@ -15,7 +16,7 @@ class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
   )(implicit F: ConcurrentEffect[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val listener = Fs2UnaryServerCallListener[F](call, options).unsafeRun()
+        val listener = Fs2UnaryServerCallListener[F](call, F.unit, options).unsafeRun()
         listener.unsafeUnaryResponse(headers, _ flatMap { request => implementation(request, headers) })
         listener
       }
@@ -27,12 +28,16 @@ class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
   )(implicit F: ConcurrentEffect[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val listener = Fs2UnaryServerCallListener[F](call, options).unsafeRun()
-        listener.unsafeStreamResponse(
-          new Metadata(),
-          v => Stream.eval(v) flatMap { request => implementation(request, headers) }
-        )
-        listener
+        Readiness[F].flatMap { readiness =>
+          Fs2UnaryServerCallListener[F](call, readiness.signal, options).map { listener =>
+            listener.unsafeStreamResponse(
+              readiness,
+              new Metadata(),
+              v => Stream.eval(v) flatMap { request => implementation(request, headers) }
+            )
+            listener
+          }
+        }.unsafeRun()
       }
     }
 
@@ -42,7 +47,7 @@ class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
   )(implicit F: ConcurrentEffect[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val listener = Fs2StreamServerCallListener[F](call, options).unsafeRun()
+        val listener = Fs2StreamServerCallListener[F](call, F.unit, options).unsafeRun()
         listener.unsafeUnaryResponse(headers, implementation(_, headers))
         listener
       }
@@ -54,9 +59,13 @@ class Fs2ServerCallHandler[F[_]](val dummy: Boolean = false) extends AnyVal {
   )(implicit F: ConcurrentEffect[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val listener = Fs2StreamServerCallListener[F](call, options).unsafeRun()
-        listener.unsafeStreamResponse(headers, implementation(_, headers))
-        listener
+
+        Readiness[F].flatMap { readiness =>
+          Fs2StreamServerCallListener[F](call, readiness.signal, options).map { listener=>
+            listener.unsafeStreamResponse(readiness, headers, implementation(_, headers))
+            listener
+          }
+        }.unsafeRun()
       }
     }
 }

--- a/java-runtime/src/main/scala/server/models.scala
+++ b/java-runtime/src/main/scala/server/models.scala
@@ -5,14 +5,17 @@ package server
 sealed abstract class ServerCompressor(val name: String) extends Product with Serializable
 case object GzipCompressor extends ServerCompressor("gzip")
 
-abstract class ServerCallOptions private (val compressor: Option[ServerCompressor]) {
-  def copy(compressor: Option[ServerCompressor] = this.compressor): ServerCallOptions =
-    new ServerCallOptions(compressor) {}
+abstract class ServerCallOptions private (val compressor: Option[ServerCompressor], val prefetchN: Int) {
+  def copy(compressor: Option[ServerCompressor] = this.compressor, prefetchN: Int = this.prefetchN): ServerCallOptions =
+    new ServerCallOptions(compressor, prefetchN) {}
 
   def withServerCompressor(compressor: Option[ServerCompressor]): ServerCallOptions =
-    copy(compressor)
+    copy(compressor = compressor)
+
+  def withPrefetchN(prefetchN: Int): ServerCallOptions =
+    copy(prefetchN = prefetchN)
 }
 
 object ServerCallOptions {
-  val default: ServerCallOptions = new ServerCallOptions(None) {}
+  val default: ServerCallOptions = new ServerCallOptions(None, 1) {}
 }

--- a/java-runtime/src/test/scala/client/DummyClientCall.scala
+++ b/java-runtime/src/test/scala/client/DummyClientCall.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable.ArrayBuffer
 import io.grpc._
 
 class DummyClientCall extends ClientCall[String, Int] {
+  var ready = true
   var requested: Int = 0
   val messagesSent: ArrayBuffer[String] = ArrayBuffer[String]()
   var listener: Option[ClientCall.Listener[Int]] = None
@@ -24,5 +25,14 @@ class DummyClientCall extends ClientCall[String, Int] {
   override def sendMessage(message: String): Unit = {
     messagesSent += message
     ()
+  }
+
+  override def isReady: Boolean = ready
+
+  def setIsReady(value: Boolean): Unit = {
+    ready = value
+    if (value) {
+      listener.foreach(_.onReady())
+    }
   }
 }

--- a/java-runtime/src/test/scala/server/DummyServerCall.scala
+++ b/java-runtime/src/test/scala/server/DummyServerCall.scala
@@ -7,9 +7,13 @@ import scala.collection.mutable.ArrayBuffer
 class DummyServerCall extends ServerCall[String, Int] {
   val messages: ArrayBuffer[Int] = ArrayBuffer[Int]()
   var currentStatus: Option[Status] = None
+  var requested: Int = 0
   private var ready = true
 
-  override def request(numMessages: Int): Unit = ()
+  override def request(numMessages: Int): Unit = {
+    requested += numMessages
+  }
+
   override def sendMessage(message: Int): Unit = {
     messages += message
     ()

--- a/java-runtime/src/test/scala/server/DummyServerCall.scala
+++ b/java-runtime/src/test/scala/server/DummyServerCall.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable.ArrayBuffer
 class DummyServerCall extends ServerCall[String, Int] {
   val messages: ArrayBuffer[Int] = ArrayBuffer[Int]()
   var currentStatus: Option[Status] = None
+  private var ready = true
 
   override def request(numMessages: Int): Unit = ()
   override def sendMessage(message: Int): Unit = {
@@ -21,4 +22,13 @@ class DummyServerCall extends ServerCall[String, Int] {
     currentStatus = Some(status)
   }
   override def isCancelled: Boolean = false
+
+  override def isReady: Boolean = ready
+
+  def setIsReady(value: Boolean, listener: ServerCall.Listener[_]): Unit = {
+    ready = value
+    if (ready) {
+      listener.onReady()
+    }
+  }
 }

--- a/java-runtime/src/test/scala/server/ServerSuite.scala
+++ b/java-runtime/src/test/scala/server/ServerSuite.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 import fs2._
 import io.grpc._
 import minitest._
+import org.lyranthe.fs2_grpc.java_runtime.shared.Readiness
 
 object ServerSuite extends SimpleTestSuite {
 
@@ -23,7 +24,7 @@ object ServerSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO](dummy, options).unsafeRunSync()
+    val listener = Fs2UnaryServerCallListener[IO](dummy, IO.unit, options).unsafeRunSync()
 
     listener.unsafeUnaryResponse(new Metadata(), _.map(_.length))
     listener.onMessage("123")
@@ -43,7 +44,7 @@ object ServerSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO](dummy).unsafeRunSync()
+    val listener = Fs2UnaryServerCallListener[IO](dummy, IO.unit).unsafeRunSync()
 
     listener.unsafeUnaryResponse(new Metadata(), _.map(_.length))
     listener.onCancel()
@@ -65,7 +66,7 @@ object ServerSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO](dummy, options).unsafeRunSync()
+    val listener = Fs2UnaryServerCallListener[IO](dummy, IO.unit, options).unsafeRunSync()
 
     listener.unsafeUnaryResponse(new Metadata(), _.map(_.length))
     listener.onMessage("123")
@@ -103,9 +104,9 @@ object ServerSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy = new DummyServerCall
-    val listener = Fs2UnaryServerCallListener[IO].apply[String, Int](dummy, options).unsafeRunSync()
+    val listener = Fs2UnaryServerCallListener[IO].apply[String, Int](dummy, IO.unit, options).unsafeRunSync()
 
-    listener.unsafeStreamResponse(new Metadata(), s => Stream.eval(s).map(_.length).repeat.take(5))
+    listener.unsafeStreamResponse(Readiness.noop, new Metadata(), s => Stream.eval(s).map(_.length).repeat.take(5))
     listener.onMessage("123")
     listener.onHalfClose()
 
@@ -123,9 +124,9 @@ object ServerSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy).unsafeRunSync()
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, IO.unit).unsafeRunSync()
 
-    listener.unsafeStreamResponse(new Metadata(), _ => Stream.emit(3).repeat.take(5))
+    listener.unsafeStreamResponse(Readiness.noop, new Metadata(), _ => Stream.emit(3).repeat.take(5))
     listener.onHalfClose()
 
     ec.tick()
@@ -142,9 +143,9 @@ object ServerSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy).unsafeRunSync()
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, IO.unit).unsafeRunSync()
 
-    listener.unsafeStreamResponse(new Metadata(), _ => Stream.emit(3).repeat.take(5))
+    listener.unsafeStreamResponse(Readiness.noop, new Metadata(), _ => Stream.emit(3).repeat.take(5))
 
     listener.onCancel()
 
@@ -165,9 +166,9 @@ object ServerSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, options).unsafeRunSync()
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, IO.unit, options).unsafeRunSync()
 
-    listener.unsafeStreamResponse(new Metadata(), _.map(_.length).intersperse(0))
+    listener.unsafeStreamResponse(Readiness.noop, new Metadata(), _.map(_.length).intersperse(0))
     listener.onMessage("a")
     listener.onMessage("ab")
     listener.onHalfClose()
@@ -186,9 +187,10 @@ object ServerSuite extends SimpleTestSuite {
     implicit val cs: ContextShift[IO] = IO.contextShift(ec)
 
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy).unsafeRunSync()
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, IO.unit).unsafeRunSync()
 
     listener.unsafeStreamResponse(
+      Readiness.noop,
       new Metadata(),
       _.map(_.length) ++ Stream.emit(0) ++ Stream.raiseError[IO](new RuntimeException("hello"))
     )
@@ -205,6 +207,66 @@ object ServerSuite extends SimpleTestSuite {
     assertEquals(dummy.currentStatus.get.isOk, false)
   }
 
+  test("streamingToStreaming send respects isReady") {
+    implicit val ec: TestContext = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val dummy = new DummyServerCall
+    val readiness = Readiness[IO].unsafeRunSync()
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, readiness.signal).unsafeRunSync()
+
+    listener.unsafeStreamResponse(
+      readiness,
+      new Metadata(),
+      requests => unreadyAfterTwoEmissions(dummy, listener).concurrently(requests)
+    )
+
+    ec.tick()
+
+    assertEquals(dummy.messages.toList, List(1, 2))
+
+    dummy.setIsReady(true, listener)
+    ec.tick()
+
+    assertEquals(dummy.messages.length, 5)
+    assertEquals(dummy.messages.toList, List(1, 2, 3, 4, 5))
+  }
+
+  test("unaryToStreaming send respects isReady") {
+    implicit val ec: TestContext = TestContext()
+    implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+    val dummy = new DummyServerCall
+    val readiness = Readiness[IO].unsafeRunSync()
+    val listener = Fs2UnaryServerCallListener[IO].apply[String, Int](dummy, readiness.signal).unsafeRunSync()
+
+    listener.unsafeStreamResponse(
+      readiness,
+      new Metadata(),
+      _ => unreadyAfterTwoEmissions(dummy, listener)
+    )
+
+    listener.onMessage("a")
+    ec.tick()
+
+    assertEquals(dummy.messages.toList, List(1, 2))
+
+    dummy.setIsReady(true, listener)
+    ec.tick()
+
+    assertEquals(dummy.messages.length, 5)
+    assertEquals(dummy.messages.toList, List(1, 2, 3, 4, 5))
+  }
+
+  private def unreadyAfterTwoEmissions(dummy: DummyServerCall, listener: ServerCall.Listener[_]) = {
+    Stream.emits(List(1, 2, 3, 4, 5))
+      .unchunk
+      .map { value =>
+        if (value == 3) dummy.setIsReady(false, listener)
+        value
+      }
+  }
+
   test("streaming to unary")(streamingToUnary())
 
   test("streaming to unary with compression")(streamingToUnary(compressionOps))
@@ -218,7 +280,7 @@ object ServerSuite extends SimpleTestSuite {
       _.compile.foldMonoid.map(_.length)
 
     val dummy = new DummyServerCall
-    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, options).unsafeRunSync()
+    val listener = Fs2StreamServerCallListener[IO].apply[String, Int](dummy, IO.unit, options).unsafeRunSync()
 
     listener.unsafeUnaryResponse(new Metadata(), implementation)
     listener.onMessage("ab")


### PR DESCRIPTION
Disappointingly after testing #544, my simple test case of "client sends 2mb chunks as fast as it can, server takes 1s to process each chunk" still died a slightly slower death. Thankfully the fix is just to reuse the nice client-side stream reception code.

I haven't yet checked if this issue exists on `main`, but I'm recording it as a necessary patch for v0.x to fully support backpressure.

(**note**: this PR is only about the _second_ commit, the first is already part of #544)