### PR TITLE
Implement backpressure for sending streams

### DIFF
--- a/runtime/src/main/scala/fs2/grpc/client/Fs2ClientCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/Fs2ClientCall.scala
@@ -23,11 +23,12 @@ package fs2
 package grpc
 package client
 
-import cats.syntax.all._
-import cats.effect.{Async, Resource}
 import cats.effect.std.Dispatcher
+import cats.effect.{Async, Resource, SyncIO}
+import cats.syntax.all._
 import fs2.grpc.client.internal.Fs2UnaryCallHandler
-import io.grpc.{Metadata, _}
+import fs2.grpc.shared.StreamOutput
+import io.grpc._
 
 final case class UnaryResult[A](value: Option[A], status: Option[GrpcStatus])
 final case class GrpcStatus(status: Status, trailers: Metadata)
@@ -51,17 +52,11 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (
   private def request(numMessages: Int): F[Unit] =
     F.delay(call.request(numMessages))
 
-  private def sendMessage(message: Request): F[Unit] =
-    F.delay(call.sendMessage(message))
-
   private def start[A <: ClientCall.Listener[Response]](createListener: F[A], md: Metadata): F[A] =
     createListener.flatTap(l => F.delay(call.start(l, md)))
 
   private def sendSingleMessage(message: Request): F[Unit] =
-    sendMessage(message) *> halfClose
-
-  private def sendStream(stream: Stream[F, Request]): Stream[F, Unit] =
-    stream.evalMap(sendMessage) ++ Stream.eval(halfClose)
+    F.delay(call.sendMessage(message)) *> halfClose
 
   //
 
@@ -69,17 +64,27 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (
     Fs2UnaryCallHandler.unary(call, options, message, headers)
 
   def streamingToUnaryCall(messages: Stream[F, Request], headers: Metadata): F[Response] =
-    Fs2UnaryCallHandler.stream(call, options, messages, headers)
+    StreamOutput.client(call, dispatcher).flatMap { output =>
+      Fs2UnaryCallHandler.stream(call, options, messages, output, headers)
+    }
 
   def unaryToStreamingCall(message: Request, md: Metadata): Stream[F, Response] =
     Stream
-      .resource(mkStreamListenerR(md))
+      .resource(mkStreamListenerR(md, SyncIO.unit))
       .flatMap(Stream.exec(sendSingleMessage(message)) ++ _.stream.adaptError(ea))
 
-  def streamingToStreamingCall(messages: Stream[F, Request], md: Metadata): Stream[F, Response] =
+  def streamingToStreamingCall(messages: Stream[F, Request], md: Metadata): Stream[F, Response] = {
+    val listenerAndOutput = Resource.eval(StreamOutput.client(call, dispatcher)).flatMap { output =>
+      mkStreamListenerR(md, output.onReady).map((_, output))
+    }
+
     Stream
-      .resource(mkStreamListenerR(md))
-      .flatMap(_.stream.adaptError(ea).concurrently(sendStream(messages)))
+      .resource(listenerAndOutput)
+      .flatMap { case (listener, output) =>
+        listener.stream.adaptError(ea)
+          .concurrently(output.writeStream(messages) ++ Stream.eval(halfClose))
+      }
+  }
 
   //
 
@@ -89,10 +94,9 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (
     case (_, Resource.ExitCase.Errored(t)) => cancel(t.getMessage.some, t.some)
   }
 
-  private def mkStreamListenerR(md: Metadata): Resource[F, Fs2StreamClientCallListener[F, Response]] = {
-
+  private def mkStreamListenerR(md: Metadata, signalReadiness: SyncIO[Unit]): Resource[F, Fs2StreamClientCallListener[F, Response]] = {
     val prefetchN = options.prefetchN.max(1)
-    val create = Fs2StreamClientCallListener.create[F, Response](request, dispatcher, prefetchN)
+    val create = Fs2StreamClientCallListener.create[F, Response](request, signalReadiness, dispatcher, prefetchN)
     val acquire = start(create, md) <* request(prefetchN)
     val release = handleExitCase(cancelSucceed = true)
 

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCall.scala
@@ -33,7 +33,7 @@ private[server] class Fs2ServerCall[F[_], Request, Response](val call: ServerCal
   def closeStream(status: Status, trailers: Metadata)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.close(status, trailers))
 
-  def sendMessage(message: Response)(implicit F: Sync[F]): F[Unit] =
+  def sendSingleMessage(message: Response)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.sendMessage(message))
 
   def request(numMessages: Int)(implicit F: Sync[F]): F[Unit] =

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
@@ -23,9 +23,10 @@ package fs2
 package grpc
 package server
 
-import cats.syntax.all._
 import cats.effect._
 import cats.effect.std.Dispatcher
+import cats.syntax.all._
+import fs2.grpc.shared.StreamOutput
 import io.grpc.{Metadata, Status, StatusException, StatusRuntimeException}
 
 private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
@@ -49,10 +50,10 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   }
 
   private def handleUnaryResponse(headers: Metadata, response: F[Response])(implicit F: Sync[F]): F[Unit] =
-    call.sendHeaders(headers) *> call.request(1) *> response >>= call.sendMessage
+    call.sendHeaders(headers) *> call.request(1) *> response >>= call.sendSingleMessage
 
-  private def handleStreamResponse(headers: Metadata, response: Stream[F, Response])(implicit F: Sync[F]): F[Unit] =
-    call.sendHeaders(headers) *> call.request(1) *> response.evalMap(call.sendMessage).compile.drain
+  private def handleStreamResponse(headers: Metadata, sendResponse: Stream[F, Unit])(implicit F: Sync[F]): F[Unit] =
+    call.sendHeaders(headers) *> call.request(1) *> sendResponse.compile.drain
 
   private def unsafeRun(f: F[Unit])(implicit F: Async[F]): Unit = {
     val bracketed = F.guaranteeCase(f) {
@@ -70,8 +71,8 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   ): Unit =
     unsafeRun(handleUnaryResponse(headers, implementation(source)))
 
-  def unsafeStreamResponse(headers: Metadata, implementation: G[Request] => Stream[F, Response])(implicit
+  def unsafeStreamResponse(streamOutput: StreamOutput[F, Response], headers: Metadata, implementation: G[Request] => Stream[F, Response])(implicit
       F: Async[F]
   ): Unit =
-    unsafeRun(handleStreamResponse(headers, implementation(source)))
+    unsafeRun(handleStreamResponse(headers, streamOutput.writeStream(implementation(source))))
 }

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
@@ -21,12 +21,10 @@
 
 package fs2.grpc.server.internal
 
-import cats.effect.Ref
-import cats.effect.Sync
-import cats.effect.SyncIO
 import cats.effect.std.Dispatcher
-import fs2.grpc.server.ServerCallOptions
-import fs2.grpc.server.ServerOptions
+import cats.effect.{Async, Ref, Sync, SyncIO}
+import fs2.grpc.server.{ServerCallOptions, ServerOptions}
+import fs2.grpc.shared.StreamOutput
 import io.grpc._
 
 private[server] object Fs2UnaryServerCallHandler {
@@ -49,6 +47,7 @@ private[server] object Fs2UnaryServerCallHandler {
 
   private def mkListener[Request, Response](
       call: Fs2ServerCall[Request, Response],
+      signalReadiness: SyncIO[Unit],
       state: Ref[SyncIO, CallerState[Request]]
   ): ServerCall.Listener[Request] =
     new ServerCall.Listener[Request] {
@@ -84,6 +83,8 @@ private[server] object Fs2UnaryServerCallHandler {
           }
           .unsafeRunSync()
 
+      override def onReady(): Unit = signalReadiness.unsafeRunSync()
+
       private def sendError(status: Status): SyncIO[Unit] =
         state.set(Cancelled()) >> call.close(status, new Metadata())
     }
@@ -97,23 +98,28 @@ private[server] object Fs2UnaryServerCallHandler {
       private val opt = options.callOptionsFn(ServerCallOptions.default)
 
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] =
-        startCallSync(call, opt)(call => req => call.unary(impl(req, headers), dispatcher)).unsafeRunSync()
+        startCallSync(call, SyncIO.unit, opt)(call => req => call.unary(impl(req, headers), dispatcher)).unsafeRunSync()
     }
 
-  def stream[F[_]: Sync, Request, Response](
+  def stream[F[_], Request, Response](
       impl: (Request, Metadata) => fs2.Stream[F, Response],
       options: ServerOptions,
       dispatcher: Dispatcher[F]
-  ): ServerCallHandler[Request, Response] =
+  )(implicit F: Async[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       private val opt = options.callOptionsFn(ServerCallOptions.default)
 
-      def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] =
-        startCallSync(call, opt)(call => req => call.stream(impl(req, headers), dispatcher)).unsafeRunSync()
+      def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
+        val outputStream = dispatcher.unsafeRunSync(StreamOutput.server(call, dispatcher))
+        startCallSync(call, outputStream.onReady, opt)(call => req => {
+          call.stream(outputStream.writeStream, impl(req, headers), dispatcher)
+        }).unsafeRunSync()
+      }
     }
 
   private def startCallSync[F[_], Request, Response](
       call: ServerCall[Request, Response],
+      signalReadiness: SyncIO[Unit],
       options: ServerCallOptions
   )(f: Fs2ServerCall[Request, Response] => Request => SyncIO[Cancel]): SyncIO[ServerCall.Listener[Request]] = {
     for {
@@ -122,6 +128,6 @@ private[server] object Fs2UnaryServerCallHandler {
       // sends more than 1 requests, ServerCall will catch it.
       _ <- call.request(2)
       state <- CallerState.init(f(call))
-    } yield mkListener[Request, Response](call, state)
+    } yield mkListener[Request, Response](call, signalReadiness, state)
   }
 }

--- a/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
+++ b/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
@@ -1,0 +1,65 @@
+package fs2.grpc.shared
+
+import cats.effect.std.Dispatcher
+import cats.effect.{Async, Deferred, Ref, SyncIO}
+import cats.syntax.all._
+import fs2.Stream
+import io.grpc.{ClientCall, ServerCall}
+
+private[grpc] trait StreamOutput[F[_], T] {
+  def onReady: SyncIO[Unit]
+
+  def writeStream(s: Stream[F, T]): Stream[F, Unit]
+}
+
+private [grpc] object StreamOutput {
+  def client[F[_], Request, Response](
+    c: ClientCall[Request, Response],
+    dispatcher: Dispatcher[F]
+  )(implicit F: Async[F]): F[StreamOutput[F, Request]] = {
+    Ref[F].of(Option.empty[Deferred[F, Unit]]).map { waiting =>
+      new StreamOutputImpl[F, Request](waiting, dispatcher,
+        isReady = F.delay(c.isReady),
+        sendMessage = m => F.delay(c.sendMessage(m)))
+    }
+  }
+
+  def server[F[_], Request, Response](
+    c: ServerCall[Request, Response],
+    dispatcher: Dispatcher[F]
+  )(implicit F: Async[F]): F[StreamOutput[F, Response]] = {
+    Ref[F].of(Option.empty[Deferred[F, Unit]]).map { waiting =>
+      new StreamOutputImpl[F, Response](waiting, dispatcher,
+        isReady = F.delay(c.isReady),
+        sendMessage = m => F.delay(c.sendMessage(m)))
+    }
+  }
+}
+
+private[grpc] class StreamOutputImpl[F[_], T](
+  waiting: Ref[F, Option[Deferred[F, Unit]]],
+  dispatcher: Dispatcher[F],
+  isReady: F[Boolean],
+  sendMessage: T => F[Unit],
+)(implicit F: Async[F]) extends StreamOutput[F, T] {
+  override def onReady: SyncIO[Unit] = SyncIO.delay(dispatcher.unsafeRunAndForget(signal))
+
+  private def signal: F[Unit] = waiting.getAndSet(None).flatMap {
+    case None => F.unit
+    case Some(wake) => wake.complete(()).void
+  }
+
+  override def writeStream(s: Stream[F, T]): Stream[F, Unit] = s.evalMap(sendWhenReady)
+
+  private def sendWhenReady(msg: T): F[Unit] = {
+    val send = sendMessage(msg)
+    isReady.ifM(send, {
+      Deferred[F, Unit].flatMap { wakeup =>
+        waiting.set(wakeup.some) *>
+          isReady.ifM(signal, F.unit) *> // trigger manually in case onReady was invoked before we installed wakeup
+          wakeup.get *>
+          send
+      }
+    })
+  }
+}

--- a/runtime/src/test/scala/fs2/grpc/client/DummyClientCall.scala
+++ b/runtime/src/test/scala/fs2/grpc/client/DummyClientCall.scala
@@ -30,6 +30,7 @@ class DummyClientCall extends ClientCall[String, Int] {
   var requested: Int = 0
   val messagesSent: ArrayBuffer[String] = ArrayBuffer[String]()
   var listener: Option[ClientCall.Listener[Int]] = None
+  var ready = true
   var cancelled: Option[(String, Throwable)] = None
   var halfClosed = false
 
@@ -47,5 +48,14 @@ class DummyClientCall extends ClientCall[String, Int] {
   override def sendMessage(message: String): Unit = {
     messagesSent += message
     ()
+  }
+
+  override def isReady: Boolean = ready
+
+  def setIsReady(value: Boolean): Unit = {
+    ready = value
+    if (value) {
+      listener.get.onReady()
+    }
   }
 }

--- a/runtime/src/test/scala/fs2/grpc/server/DummyServerCall.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/DummyServerCall.scala
@@ -30,6 +30,7 @@ import scala.collection.mutable.ArrayBuffer
 class DummyServerCall extends ServerCall[String, Int] {
   val messages: ArrayBuffer[Int] = ArrayBuffer[Int]()
   var currentStatus: Option[Status] = None
+  var ready: Boolean = true
 
   override def request(numMessages: Int): Unit = ()
   override def sendMessage(message: Int): Unit = {
@@ -44,4 +45,12 @@ class DummyServerCall extends ServerCall[String, Int] {
     currentStatus = Some(status)
   }
   override def isCancelled: Boolean = false
+
+  override def isReady: Boolean = ready
+  def setIsReady(value: Boolean, listener: ServerCall.Listener[_]): Unit = {
+    ready = value
+    if (ready) {
+      listener.onReady()
+    }
+  }
 }


### PR DESCRIPTION
I'm not sure whether the v0.x branch is still maintained, so here's a version of #544 against `main`.