### PR TITLE
Remove unbounded queue on server-side stream reception

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,9 @@ inThisBuild(
     mimaBinaryIssueFilters ++= Seq(
       // API that is not extended by end-users
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.mkClient"),
-      // package private API
+      // package private APIs
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.client.StreamIngest.create"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.server.Fs2StreamServerCallListener*"),
       // deleted private classes
       ProblemFilters.exclude[MissingClassProblem]("fs2.grpc.client.Fs2UnaryClientCallListener*"),
       ProblemFilters.exclude[MissingClassProblem]("fs2.grpc.server.Fs2UnaryServerCallListener*")

--- a/runtime/src/main/scala/fs2/grpc/client/Fs2ClientCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/Fs2ClientCall.scala
@@ -23,11 +23,12 @@ package fs2
 package grpc
 package client
 
-import cats.syntax.all._
-import cats.effect.{Async, Resource}
 import cats.effect.std.Dispatcher
+import cats.effect.{Async, Resource, SyncIO}
+import cats.syntax.all._
 import fs2.grpc.client.internal.Fs2UnaryCallHandler
-import io.grpc.{Metadata, _}
+import fs2.grpc.shared.StreamOutput
+import io.grpc._
 
 final case class UnaryResult[A](value: Option[A], status: Option[GrpcStatus])
 final case class GrpcStatus(status: Status, trailers: Metadata)
@@ -51,17 +52,11 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (
   private def request(numMessages: Int): F[Unit] =
     F.delay(call.request(numMessages))
 
-  private def sendMessage(message: Request): F[Unit] =
-    F.delay(call.sendMessage(message))
-
   private def start[A <: ClientCall.Listener[Response]](createListener: F[A], md: Metadata): F[A] =
     createListener.flatTap(l => F.delay(call.start(l, md)))
 
   private def sendSingleMessage(message: Request): F[Unit] =
-    sendMessage(message) *> halfClose
-
-  private def sendStream(stream: Stream[F, Request]): Stream[F, Unit] =
-    stream.evalMap(sendMessage) ++ Stream.eval(halfClose)
+    F.delay(call.sendMessage(message)) *> halfClose
 
   //
 
@@ -69,17 +64,27 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (
     Fs2UnaryCallHandler.unary(call, options, message, headers)
 
   def streamingToUnaryCall(messages: Stream[F, Request], headers: Metadata): F[Response] =
-    Fs2UnaryCallHandler.stream(call, options, messages, headers)
+    StreamOutput.client(call, dispatcher).flatMap { output =>
+      Fs2UnaryCallHandler.stream(call, options, messages, output, headers)
+    }
 
   def unaryToStreamingCall(message: Request, md: Metadata): Stream[F, Response] =
     Stream
-      .resource(mkStreamListenerR(md))
+      .resource(mkStreamListenerR(md, SyncIO.unit))
       .flatMap(Stream.exec(sendSingleMessage(message)) ++ _.stream.adaptError(ea))
 
-  def streamingToStreamingCall(messages: Stream[F, Request], md: Metadata): Stream[F, Response] =
+  def streamingToStreamingCall(messages: Stream[F, Request], md: Metadata): Stream[F, Response] = {
+    val listenerAndOutput = Resource.eval(StreamOutput.client(call, dispatcher)).flatMap { output =>
+      mkStreamListenerR(md, output.onReady).map((_, output))
+    }
+
     Stream
-      .resource(mkStreamListenerR(md))
-      .flatMap(_.stream.adaptError(ea).concurrently(sendStream(messages)))
+      .resource(listenerAndOutput)
+      .flatMap { case (listener, output) =>
+        listener.stream.adaptError(ea)
+          .concurrently(output.writeStream(messages) ++ Stream.eval(halfClose))
+      }
+  }
 
   //
 
@@ -89,10 +94,9 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (
     case (_, Resource.ExitCase.Errored(t)) => cancel(t.getMessage.some, t.some)
   }
 
-  private def mkStreamListenerR(md: Metadata): Resource[F, Fs2StreamClientCallListener[F, Response]] = {
-
+  private def mkStreamListenerR(md: Metadata, signalReadiness: SyncIO[Unit]): Resource[F, Fs2StreamClientCallListener[F, Response]] = {
     val prefetchN = options.prefetchN.max(1)
-    val create = Fs2StreamClientCallListener.create[F, Response](request, dispatcher, prefetchN)
+    val create = Fs2StreamClientCallListener.create[F, Response](request, signalReadiness, dispatcher, prefetchN)
     val acquire = start(create, md) <* request(prefetchN)
     val release = handleExitCase(cancelSucceed = true)
 

--- a/runtime/src/main/scala/fs2/grpc/client/Fs2StreamClientCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/Fs2StreamClientCallListener.scala
@@ -29,7 +29,7 @@ import cats.effect.kernel.Concurrent
 import cats.effect.std.Dispatcher
 import io.grpc.{ClientCall, Metadata, Status}
 
-class Fs2StreamClientCallListener[F[_], Response] private (
+private[client] class Fs2StreamClientCallListener[F[_], Response] private (
     ingest: StreamIngest[F, Response],
     signalReadiness: SyncIO[Unit],
     dispatcher: Dispatcher[F]
@@ -48,9 +48,9 @@ class Fs2StreamClientCallListener[F[_], Response] private (
   val stream: Stream[F, Response] = ingest.messages
 }
 
-object Fs2StreamClientCallListener {
+private[client] object Fs2StreamClientCallListener {
 
-  private[client] def create[F[_]: Concurrent, Response](
+  def create[F[_]: Concurrent, Response](
       request: Int => F[Unit],
       signalReadiness: SyncIO[Unit],
       dispatcher: Dispatcher[F],

--- a/runtime/src/main/scala/fs2/grpc/client/Fs2StreamClientCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/Fs2StreamClientCallListener.scala
@@ -39,7 +39,7 @@ class Fs2StreamClientCallListener[F[_], Response] private (
     dispatcher.unsafeRunSync(ingest.onMessage(message))
 
   override def onClose(status: Status, trailers: Metadata): Unit = {
-    val error = Option.when(!status.isOk)(status.asRuntimeException(trailers))
+    val error = if (status.isOk) None else Some(status.asRuntimeException(trailers))
     dispatcher.unsafeRunSync(ingest.onClose(error))
   }
 

--- a/runtime/src/main/scala/fs2/grpc/client/internal/Fs2UnaryCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/internal/Fs2UnaryCallHandler.scala
@@ -144,7 +144,11 @@ private[client] object Fs2UnaryCallHandler {
       // Initially ask for two responses from flow-control so that if a misbehaving server
       // sends more than one responses, we can catch it and fail it in the listener.
       call.request(2)
-      output.writeStream(messages).compile.drain.guaranteeCase {
+      output
+        .writeStream(messages)
+        .compile
+        .drain
+        .guaranteeCase {
           case Outcome.Succeeded(_) => F.delay(call.halfClose())
           case Outcome.Errored(e) => F.delay(call.cancel(e.getMessage, e))
           case Outcome.Canceled() => onCancel(call)

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCall.scala
@@ -33,7 +33,7 @@ private[server] class Fs2ServerCall[F[_], Request, Response](val call: ServerCal
   def closeStream(status: Status, trailers: Metadata)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.close(status, trailers))
 
-  def sendMessage(message: Response)(implicit F: Sync[F]): F[Unit] =
+  def sendSingleMessage(message: Response)(implicit F: Sync[F]): F[Unit] =
     F.delay(call.sendMessage(message))
 
   def request(numMessages: Int)(implicit F: Sync[F]): F[Unit] =

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallHandler.scala
@@ -59,8 +59,8 @@ class Fs2ServerCallHandler[F[_]: Async] private (
       implementation: (Stream[F, Request], Metadata) => Stream[F, Response]
   ): ServerCallHandler[Request, Response] = new ServerCallHandler[Request, Response] {
     def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-      val (listener, streamOutput) = dispatcher.unsafeRunSync(StreamOutput.server(call, dispatcher).flatMap { output =>
-        Fs2StreamServerCallListener[F](call, output.onReady, dispatcher, options).map((_, output))
+      val (listener, streamOutput) = dispatcher.unsafeRunSync(StreamOutput.server(call).flatMap { output =>
+        Fs2StreamServerCallListener[F](call, output.onReadySync(dispatcher), dispatcher, options).map((_, output))
       })
       listener.unsafeStreamResponse(streamOutput, new Metadata(), implementation(_, headers))
       listener

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
@@ -23,9 +23,10 @@ package fs2
 package grpc
 package server
 
-import cats.syntax.all._
 import cats.effect._
 import cats.effect.std.Dispatcher
+import cats.syntax.all._
+import fs2.grpc.shared.StreamOutput
 import io.grpc.{Metadata, Status, StatusException, StatusRuntimeException}
 
 private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
@@ -49,10 +50,10 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   }
 
   private def handleUnaryResponse(headers: Metadata, response: F[Response])(implicit F: Sync[F]): F[Unit] =
-    call.sendHeaders(headers) *> call.request(1) *> response >>= call.sendMessage
+    call.sendHeaders(headers) *> call.request(1) *> response >>= call.sendSingleMessage
 
-  private def handleStreamResponse(headers: Metadata, response: Stream[F, Response])(implicit F: Sync[F]): F[Unit] =
-    call.sendHeaders(headers) *> call.request(1) *> response.evalMap(call.sendMessage).compile.drain
+  private def handleStreamResponse(headers: Metadata, sendResponse: Stream[F, Unit])(implicit F: Sync[F]): F[Unit] =
+    call.sendHeaders(headers) *> call.request(1) *> sendResponse.compile.drain
 
   private def unsafeRun(f: F[Unit])(implicit F: Async[F]): Unit = {
     val bracketed = F.guaranteeCase(f) {
@@ -70,8 +71,8 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   ): Unit =
     unsafeRun(handleUnaryResponse(headers, implementation(source)))
 
-  def unsafeStreamResponse(headers: Metadata, implementation: G[Request] => Stream[F, Response])(implicit
+  def unsafeStreamResponse(streamOutput: StreamOutput[F, Response], headers: Metadata, implementation: G[Request] => Stream[F, Response])(implicit
       F: Async[F]
   ): Unit =
-    unsafeRun(handleStreamResponse(headers, implementation(source)))
+    unsafeRun(handleStreamResponse(headers, streamOutput.writeStream(implementation(source))))
 }

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
@@ -71,7 +71,11 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   ): Unit =
     unsafeRun(handleUnaryResponse(headers, implementation(source)))
 
-  def unsafeStreamResponse(streamOutput: StreamOutput[F, Response], headers: Metadata, implementation: G[Request] => Stream[F, Response])(implicit
+  def unsafeStreamResponse(
+      streamOutput: StreamOutput[F, Response],
+      headers: Metadata,
+      implementation: G[Request] => Stream[F, Response]
+  )(implicit
       F: Async[F]
   ): Unit =
     unsafeRun(handleStreamResponse(headers, streamOutput.writeStream(implementation(source))))

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2StreamServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2StreamServerCallListener.scala
@@ -31,7 +31,7 @@ import cats.effect.std.Dispatcher
 import fs2.grpc.client.StreamIngest
 import io.grpc.ServerCall
 
-class Fs2StreamServerCallListener[F[_], Request, Response] private (
+private[server] class Fs2StreamServerCallListener[F[_], Request, Response] private (
     ingest: StreamIngest[F, Request],
     signalReadiness: SyncIO[Unit],
     val isCancelled: Deferred[F, Unit],
@@ -55,11 +55,11 @@ class Fs2StreamServerCallListener[F[_], Request, Response] private (
   override def source: Stream[F, Request] = ingest.messages
 }
 
-object Fs2StreamServerCallListener {
+private[server] object Fs2StreamServerCallListener {
 
   class PartialFs2StreamServerCallListener[F[_]](val dummy: Boolean = false) extends AnyVal {
 
-    private[server] def apply[Request, Response](
+    def apply[Request, Response](
         call: ServerCall[Request, Response],
         signalReadiness: SyncIO[Unit],
         dispatcher: Dispatcher[F],
@@ -79,6 +79,6 @@ object Fs2StreamServerCallListener {
 
   }
 
-  private[server] def apply[F[_]] = new PartialFs2StreamServerCallListener[F]
+  def apply[F[_]] = new PartialFs2StreamServerCallListener[F]
 
 }

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2StreamServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2StreamServerCallListener.scala
@@ -69,7 +69,13 @@ object Fs2StreamServerCallListener {
       request = (n: Int) => F.delay(call.request(n))
       ingest <- StreamIngest[F, Request](request, prefetchN = 1)
       serverCall <- Fs2ServerCall[F, Request, Response](call, options)
-    } yield new Fs2StreamServerCallListener[F, Request, Response](ingest, signalReadiness, isCancelled, serverCall, dispatcher)
+    } yield new Fs2StreamServerCallListener[F, Request, Response](
+      ingest,
+      signalReadiness,
+      isCancelled,
+      serverCall,
+      dispatcher
+    )
 
   }
 

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2StreamServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2StreamServerCallListener.scala
@@ -28,10 +28,11 @@ import cats.syntax.all._
 import cats.effect.kernel.Deferred
 import cats.effect.{Async, SyncIO}
 import cats.effect.std.{Dispatcher, Queue}
+import fs2.grpc.client.StreamIngest
 import io.grpc.ServerCall
 
 class Fs2StreamServerCallListener[F[_], Request, Response] private (
-    requestQ: Queue[F, Option[Request]],
+    ingest: StreamIngest[F, Request],
     signalReadiness: SyncIO[Unit],
     val isCancelled: Deferred[F, Unit],
     val call: Fs2ServerCall[F, Request, Response],
@@ -43,18 +44,15 @@ class Fs2StreamServerCallListener[F[_], Request, Response] private (
   override def onCancel(): Unit =
     dispatcher.unsafeRunSync(isCancelled.complete(()).void)
 
-  override def onMessage(message: Request): Unit = {
-    call.call.request(1)
-    dispatcher.unsafeRunSync(requestQ.offer(message.some))
-  }
+  override def onMessage(message: Request): Unit =
+    dispatcher.unsafeRunSync(ingest.onMessage(message))
 
   override def onReady(): Unit = signalReadiness.unsafeRunSync()
 
   override def onHalfClose(): Unit =
-    dispatcher.unsafeRunSync(requestQ.offer(none))
+    dispatcher.unsafeRunSync(ingest.onClose(None))
 
-  override def source: Stream[F, Request] =
-    Stream.repeatEval(requestQ.take).unNoneTerminate
+  override def source: Stream[F, Request] = ingest.messages
 }
 
 object Fs2StreamServerCallListener {
@@ -67,10 +65,11 @@ object Fs2StreamServerCallListener {
         dispatcher: Dispatcher[F],
         options: ServerOptions
     )(implicit F: Async[F]): F[Fs2StreamServerCallListener[F, Request, Response]] = for {
-      inputQ <- Queue.unbounded[F, Option[Request]]
       isCancelled <- Deferred[F, Unit]
+      request = (n: Int) => F.delay(call.request(n))
+      ingest <- StreamIngest[F, Request](request, prefetchN = 1)
       serverCall <- Fs2ServerCall[F, Request, Response](call, options)
-    } yield new Fs2StreamServerCallListener[F, Request, Response](inputQ, signalReadiness, isCancelled, serverCall, dispatcher)
+    } yield new Fs2StreamServerCallListener[F, Request, Response](ingest, signalReadiness, isCancelled, serverCall, dispatcher)
 
   }
 

--- a/runtime/src/main/scala/fs2/grpc/server/Fs2StreamServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2StreamServerCallListener.scala
@@ -27,7 +27,7 @@ import cats.Functor
 import cats.syntax.all._
 import cats.effect.kernel.Deferred
 import cats.effect.{Async, SyncIO}
-import cats.effect.std.{Dispatcher, Queue}
+import cats.effect.std.Dispatcher
 import fs2.grpc.client.StreamIngest
 import io.grpc.ServerCall
 

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2ServerCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2ServerCall.scala
@@ -42,12 +42,16 @@ private[server] object Fs2ServerCall {
 }
 
 private[server] final class Fs2ServerCall[Request, Response](
-    call: ServerCall[Request, Response],
+    call: ServerCall[Request, Response]
 ) {
 
   import Fs2ServerCall.Cancel
 
-  def stream[F[_]](sendStream: Stream[F, Response] => Stream[F, Unit], response: Stream[F, Response], dispatcher: Dispatcher[F])(implicit F: Sync[F]): SyncIO[Cancel] =
+  def stream[F[_]](
+      sendStream: Stream[F, Response] => Stream[F, Unit],
+      response: Stream[F, Response],
+      dispatcher: Dispatcher[F]
+  )(implicit F: Sync[F]): SyncIO[Cancel] =
     run(
       response.pull.peek1
         .flatMap {

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
@@ -111,9 +111,11 @@ private[server] object Fs2UnaryServerCallHandler {
 
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
         val outputStream = dispatcher.unsafeRunSync(StreamOutput.server(call))
-        startCallSync(call, outputStream.onReadySync(dispatcher), opt)(call => req => {
-          call.stream(outputStream.writeStream, impl(req, headers), dispatcher)
-        }).unsafeRunSync()
+        startCallSync(call, outputStream.onReadySync(dispatcher), opt)(call =>
+          req => {
+            call.stream(outputStream.writeStream, impl(req, headers), dispatcher)
+          }
+        ).unsafeRunSync()
       }
     }
 

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
@@ -110,8 +110,8 @@ private[server] object Fs2UnaryServerCallHandler {
       private val opt = options.callOptionsFn(ServerCallOptions.default)
 
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
-        val outputStream = dispatcher.unsafeRunSync(StreamOutput.server(call, dispatcher))
-        startCallSync(call, outputStream.onReady, opt)(call => req => {
+        val outputStream = dispatcher.unsafeRunSync(StreamOutput.server(call))
+        startCallSync(call, outputStream.onReadySync(dispatcher), opt)(call => req => {
           call.stream(outputStream.writeStream, impl(req, headers), dispatcher)
         }).unsafeRunSync()
       }

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
@@ -21,12 +21,10 @@
 
 package fs2.grpc.server.internal
 
-import cats.effect.Ref
-import cats.effect.Sync
-import cats.effect.SyncIO
 import cats.effect.std.Dispatcher
-import fs2.grpc.server.ServerCallOptions
-import fs2.grpc.server.ServerOptions
+import cats.effect.{Async, Ref, Sync, SyncIO}
+import fs2.grpc.server.{ServerCallOptions, ServerOptions}
+import fs2.grpc.shared.StreamOutput
 import io.grpc._
 
 private[server] object Fs2UnaryServerCallHandler {
@@ -49,6 +47,7 @@ private[server] object Fs2UnaryServerCallHandler {
 
   private def mkListener[Request, Response](
       call: Fs2ServerCall[Request, Response],
+      signalReadiness: SyncIO[Unit],
       state: Ref[SyncIO, CallerState[Request]]
   ): ServerCall.Listener[Request] =
     new ServerCall.Listener[Request] {
@@ -84,6 +83,8 @@ private[server] object Fs2UnaryServerCallHandler {
           }
           .unsafeRunSync()
 
+      override def onReady(): Unit = signalReadiness.unsafeRunSync()
+
       private def sendError(status: Status): SyncIO[Unit] =
         state.set(Cancelled()) >> call.close(status, new Metadata())
     }
@@ -97,23 +98,28 @@ private[server] object Fs2UnaryServerCallHandler {
       private val opt = options.callOptionsFn(ServerCallOptions.default)
 
       def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] =
-        startCallSync(call, opt)(call => req => call.unary(impl(req, headers), dispatcher)).unsafeRunSync()
+        startCallSync(call, SyncIO.unit, opt)(call => req => call.unary(impl(req, headers), dispatcher)).unsafeRunSync()
     }
 
-  def stream[F[_]: Sync, Request, Response](
+  def stream[F[_], Request, Response](
       impl: (Request, Metadata) => fs2.Stream[F, Response],
       options: ServerOptions,
       dispatcher: Dispatcher[F]
-  ): ServerCallHandler[Request, Response] =
+  )(implicit F: Async[F]): ServerCallHandler[Request, Response] =
     new ServerCallHandler[Request, Response] {
       private val opt = options.callOptionsFn(ServerCallOptions.default)
 
-      def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] =
-        startCallSync(call, opt)(call => req => call.stream(impl(req, headers), dispatcher)).unsafeRunSync()
+      def startCall(call: ServerCall[Request, Response], headers: Metadata): ServerCall.Listener[Request] = {
+        val outputStream = dispatcher.unsafeRunSync(StreamOutput.server(call, dispatcher))
+        startCallSync(call, outputStream.onReady, opt)(call => req => {
+          call.stream(outputStream.writeStream, impl(req, headers), dispatcher)
+        }).unsafeRunSync()
+      }
     }
 
   private def startCallSync[F[_], Request, Response](
       call: ServerCall[Request, Response],
+      signalReadiness: SyncIO[Unit],
       options: ServerCallOptions
   )(f: Fs2ServerCall[Request, Response] => Request => SyncIO[Cancel]): SyncIO[ServerCall.Listener[Request]] = {
     for {
@@ -122,6 +128,6 @@ private[server] object Fs2UnaryServerCallHandler {
       // sends more than 1 requests, ServerCall will catch it.
       _ <- call.request(2)
       state <- CallerState.init(f(call))
-    } yield mkListener[Request, Response](call, state)
+    } yield mkListener[Request, Response](call, signalReadiness, state)
   }
 }

--- a/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
+++ b/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
@@ -1,35 +1,36 @@
 package fs2.grpc.shared
 
 import cats.effect.std.Dispatcher
-import cats.effect.{Async, Deferred, Ref, SyncIO}
+import cats.effect.{Async, SyncIO}
 import cats.syntax.all._
 import fs2.Stream
+import fs2.concurrent.SignallingRef
 import io.grpc.{ClientCall, ServerCall}
 
 private[grpc] trait StreamOutput[F[_], T] {
-  def onReady: SyncIO[Unit]
+  def onReady: F[Unit]
+
+  def onReadySync(dispatcher: Dispatcher[F]): SyncIO[Unit] = SyncIO.delay(dispatcher.unsafeRunSync(onReady))
 
   def writeStream(s: Stream[F, T]): Stream[F, Unit]
 }
 
 private [grpc] object StreamOutput {
-  def client[F[_], Request, Response](
-    c: ClientCall[Request, Response],
-    dispatcher: Dispatcher[F]
-  )(implicit F: Async[F]): F[StreamOutput[F, Request]] = {
-    Ref[F].of(Option.empty[Deferred[F, Unit]]).map { waiting =>
-      new StreamOutputImpl[F, Request](waiting, dispatcher,
+  def client[F[_], Request, Response](c: ClientCall[Request, Response])
+    (implicit F: Async[F]): F[StreamOutput[F, Request]] = {
+    SignallingRef[F].of(0L).map { readyState =>
+      new StreamOutputImpl[F, Request](
+        readyState,
         isReady = F.delay(c.isReady),
         sendMessage = m => F.delay(c.sendMessage(m)))
     }
   }
 
-  def server[F[_], Request, Response](
-    c: ServerCall[Request, Response],
-    dispatcher: Dispatcher[F]
-  )(implicit F: Async[F]): F[StreamOutput[F, Response]] = {
-    Ref[F].of(Option.empty[Deferred[F, Unit]]).map { waiting =>
-      new StreamOutputImpl[F, Response](waiting, dispatcher,
+  def server[F[_], Request, Response](c: ServerCall[Request, Response])
+    (implicit F: Async[F]): F[StreamOutput[F, Response]] = {
+    SignallingRef[F].of(0L).map { readyState =>
+      new StreamOutputImpl[F, Response](
+        readyState,
         isReady = F.delay(c.isReady),
         sendMessage = m => F.delay(c.sendMessage(m)))
     }
@@ -37,28 +38,23 @@ private [grpc] object StreamOutput {
 }
 
 private[grpc] class StreamOutputImpl[F[_], T](
-  waiting: Ref[F, Option[Deferred[F, Unit]]],
-  dispatcher: Dispatcher[F],
+  readyCountRef: SignallingRef[F, Long],
   isReady: F[Boolean],
   sendMessage: T => F[Unit],
 )(implicit F: Async[F]) extends StreamOutput[F, T] {
-  override def onReady: SyncIO[Unit] = SyncIO.delay(dispatcher.unsafeRunAndForget(signal))
-
-  private def signal: F[Unit] = waiting.getAndSet(None).flatMap {
-    case None => F.unit
-    case Some(wake) => wake.complete(()).void
-  }
+  override def onReady: F[Unit] = readyCountRef.update(_ + 1L)
 
   override def writeStream(s: Stream[F, T]): Stream[F, Unit] = s.evalMap(sendWhenReady)
 
   private def sendWhenReady(msg: T): F[Unit] = {
     val send = sendMessage(msg)
     isReady.ifM(send, {
-      Deferred[F, Unit].flatMap { wakeup =>
-        waiting.set(wakeup.some) *>
-          isReady.ifM(signal, F.unit) *> // trigger manually in case onReady was invoked before we installed wakeup
-          wakeup.get *>
-          send
+      readyCountRef.get.flatMap { readyState =>
+        // If isReady is now true, don't wait (we may have missed the onReady signal)
+        isReady.ifM(send, {
+          // otherwise wait until readyState has been incremented
+          readyCountRef.waitUntil(_ > readyState) *> send
+        })
       }
     })
   }

--- a/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
+++ b/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
@@ -1,0 +1,65 @@
+package fs2.grpc.shared
+
+import cats.effect.std.Dispatcher
+import cats.effect.{Async, Deferred, Ref, SyncIO}
+import cats.syntax.all._
+import fs2.Stream
+import io.grpc.{ClientCall, ServerCall}
+
+private[grpc] trait StreamOutput[F[_], T] {
+  def onReady: SyncIO[Unit]
+
+  def writeStream(s: Stream[F, T]): Stream[F, Unit]
+}
+
+private [grpc] object StreamOutput {
+  def client[F[_], Request, Response](
+    c: ClientCall[Request, Response],
+    dispatcher: Dispatcher[F]
+  )(implicit F: Async[F]): F[StreamOutput[F, Request]] = {
+    Ref[F].of(Option.empty[Deferred[F, Unit]]).map { waiting =>
+      new StreamOutputImpl[F, Request](waiting, dispatcher,
+        isReady = F.delay(c.isReady),
+        sendMessage = m => F.delay(c.sendMessage(m)))
+    }
+  }
+
+  def server[F[_], Request, Response](
+    c: ServerCall[Request, Response],
+    dispatcher: Dispatcher[F]
+  )(implicit F: Async[F]): F[StreamOutput[F, Response]] = {
+    Ref[F].of(Option.empty[Deferred[F, Unit]]).map { waiting =>
+      new StreamOutputImpl[F, Response](waiting, dispatcher,
+        isReady = F.delay(c.isReady),
+        sendMessage = m => F.delay(c.sendMessage(m)))
+    }
+  }
+}
+
+private[grpc] class StreamOutputImpl[F[_], T](
+  waiting: Ref[F, Option[Deferred[F, Unit]]],
+  dispatcher: Dispatcher[F],
+  isReady: F[Boolean],
+  sendMessage: T => F[Unit],
+)(implicit F: Async[F]) extends StreamOutput[F, T] {
+  override def onReady: SyncIO[Unit] = SyncIO.delay(dispatcher.unsafeRunAndForget(signal))
+
+  private def signal: F[Unit] = waiting.getAndSet(None).flatMap {
+    case None => F.unit
+    case Some(wake) => wake.complete(()).void
+  }
+
+  override def writeStream(s: Stream[F, T]): Stream[F, Unit] = s.evalMap(sendWhenReady)
+
+  private def sendWhenReady(msg: T): F[Unit] = {
+    val send = sendMessage(msg)
+    isReady.ifM(send, {
+      Deferred[F, Unit].flatMap { wakeup =>
+        waiting.set(wakeup.some) *>
+          isReady.ifM(signal, F.unit) *> // trigger manually in case onReady was invoked before we installed wakeup
+          wakeup.get *>
+          send
+      }
+    })
+  }
+}

--- a/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
+++ b/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package fs2.grpc.shared
 
 import cats.effect.std.Dispatcher

--- a/runtime/src/test/scala/fs2/grpc/client/ClientSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/client/ClientSuite.scala
@@ -149,7 +149,8 @@ class ClientSuite extends Fs2GrpcSuite {
   runTest0("stream to streamingToUnary - send respects readiness") { (tc, io, d) =>
     val dummy = new DummyClientCall()
     val client = fs2ClientCall(dummy, d)
-    val requests = Stream.emits(List("a", "b", "c", "d", "e"))
+    val requests = Stream
+      .emits(List("a", "b", "c", "d", "e"))
       .chunkLimit(1)
       .unchunks
       .map { value =>
@@ -279,7 +280,8 @@ class ClientSuite extends Fs2GrpcSuite {
   runTest0("stream to streamingToStreaming - send respects readiness") { (tc, io, d) =>
     val dummy = new DummyClientCall()
     val client = fs2ClientCall(dummy, d)
-    val requests = Stream.emits(List("a", "b", "c", "d", "e"))
+    val requests = Stream
+      .emits(List("a", "b", "c", "d", "e"))
       .chunkLimit(1)
       .unchunks
       .map { value =>

--- a/runtime/src/test/scala/fs2/grpc/client/DummyClientCall.scala
+++ b/runtime/src/test/scala/fs2/grpc/client/DummyClientCall.scala
@@ -30,6 +30,7 @@ class DummyClientCall extends ClientCall[String, Int] {
   var requested: Int = 0
   val messagesSent: ArrayBuffer[String] = ArrayBuffer[String]()
   var listener: Option[ClientCall.Listener[Int]] = None
+  var ready = true
   var cancelled: Option[(String, Throwable)] = None
   var halfClosed = false
 
@@ -47,5 +48,14 @@ class DummyClientCall extends ClientCall[String, Int] {
   override def sendMessage(message: String): Unit = {
     messagesSent += message
     ()
+  }
+
+  override def isReady: Boolean = ready
+
+  def setIsReady(value: Boolean): Unit = {
+    ready = value
+    if (value) {
+      listener.get.onReady()
+    }
   }
 }

--- a/runtime/src/test/scala/fs2/grpc/server/DummyServerCall.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/DummyServerCall.scala
@@ -30,9 +30,12 @@ import scala.collection.mutable.ArrayBuffer
 class DummyServerCall extends ServerCall[String, Int] {
   val messages: ArrayBuffer[Int] = ArrayBuffer[Int]()
   var currentStatus: Option[Status] = None
+  var requested: Int = 0
   var ready: Boolean = true
 
-  override def request(numMessages: Int): Unit = ()
+  override def request(numMessages: Int): Unit = {
+    requested += numMessages
+  }
   override def sendMessage(message: Int): Unit = {
     messages += message
     ()

--- a/runtime/src/test/scala/fs2/grpc/server/DummyServerCall.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/DummyServerCall.scala
@@ -30,6 +30,7 @@ import scala.collection.mutable.ArrayBuffer
 class DummyServerCall extends ServerCall[String, Int] {
   val messages: ArrayBuffer[Int] = ArrayBuffer[Int]()
   var currentStatus: Option[Status] = None
+  var ready: Boolean = true
 
   override def request(numMessages: Int): Unit = ()
   override def sendMessage(message: Int): Unit = {
@@ -44,4 +45,12 @@ class DummyServerCall extends ServerCall[String, Int] {
     currentStatus = Some(status)
   }
   override def isCancelled: Boolean = false
+
+  override def isReady: Boolean = ready
+  def setIsReady(value: Boolean, listener: ServerCall.Listener[_]): Unit = {
+    ready = value
+    if (ready) {
+      listener.onReady()
+    }
+  }
 }

--- a/runtime/src/test/scala/fs2/grpc/server/ServerSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/ServerSuite.scala
@@ -251,7 +251,11 @@ class ServerSuite extends Fs2GrpcSuite {
 
     val listenerRef = Ref.unsafe[SyncIO, Option[ServerCall.Listener[_]]](None)
     val handler =
-      Fs2UnaryServerCallHandler.stream[IO, String, Int]((_, _) => unreadyAfterTwoEmissions(dummy, listenerRef), ServerOptions.default, d)
+      Fs2UnaryServerCallHandler.stream[IO, String, Int](
+        (_, _) => unreadyAfterTwoEmissions(dummy, listenerRef),
+        ServerOptions.default,
+        d
+      )
 
     val listener = handler.startCall(dummy, new Metadata())
     listenerRef.set(Some(listener)).unsafeRunSync()
@@ -269,7 +273,8 @@ class ServerSuite extends Fs2GrpcSuite {
   }
 
   private def unreadyAfterTwoEmissions(dummy: DummyServerCall, listener: Ref[SyncIO, Option[ServerCall.Listener[_]]]) =
-    Stream.emits(List(1, 2, 3, 4, 5))
+    Stream
+      .emits(List(1, 2, 3, 4, 5))
       .chunkLimit(1)
       .unchunks
       .map { value =>


### PR DESCRIPTION
This is #545 but on top of #552 (i.e. targeting `main`).

As in the original PR, the first commit is #552, the second commit contains the changes specific to this PR.