### PR TITLE
Add service binding for mkCtx returning Resource

### DIFF
--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -43,5 +43,15 @@ object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestService
       .addMethod(hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.bothStreaming(r, _))))
       .build()
   }
+  
+  protected def serviceBindingResource[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], serviceImpl: TestServiceFs2Grpc[F, A], mkCtx: _root_.io.grpc.Metadata => _root_.cats.effect.Resource[F, A], serverOptions: _root_.fs2.grpc.server.ServerOptions): _root_.io.grpc.ServerServiceDefinition = {
+    _root_.io.grpc.ServerServiceDefinition
+      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .addMethod(hello.world.TestServiceGrpc.METHOD_NO_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).use(serviceImpl.noStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).use(serviceImpl.clientStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.resource[F, A](mkCtx(m)).flatMap(serviceImpl.serverStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.resource[F, A](mkCtx(m)).flatMap(serviceImpl.bothStreaming(r, _))))
+      .build()
+  }
 
 }

--- a/runtime/src/main/scala/fs2/grpc/GeneratedCompanion.scala
+++ b/runtime/src/main/scala/fs2/grpc/GeneratedCompanion.scala
@@ -123,6 +123,13 @@ trait GeneratedCompanion[Service[*[_], _]] {
       serverOptions: ServerOptions
   ): ServerServiceDefinition
 
+  protected def serviceBindingResource[F[_]: Async, A](
+      dispatcher: Dispatcher[F],
+      serviceImpl: Service[F, A],
+      mkCtx: Metadata => Resource[F, A],
+      serverOptions: ServerOptions
+  ): ServerServiceDefinition
+
   final def service[F[_]: Async, A](
       dispatcher: Dispatcher[F],
       serviceImpl: Service[F, A],
@@ -138,6 +145,13 @@ trait GeneratedCompanion[Service[*[_], _]] {
 
     serviceBinding[F, A](dispatcher, serviceImpl, mkCtx, serverOptions)
   }
+
+  final def service[F[_]: Async, A](
+      serviceImpl: Service[F, A],
+      f: Metadata => Resource[F, A],
+      serverOptions: ServerOptions
+  ): Resource[F, ServerServiceDefinition] =
+    Dispatcher[F].map(serviceBindingResource[F, A](_, serviceImpl, f, serverOptions))
 
   final def service[F[_]: Async, A](
       dispatcher: Dispatcher[F],


### PR DESCRIPTION
This PR adds the method `serviceBindingResource` to a service implementation's generated companion. The method is just like `serviceBinding`, but the signature on `mkCtx` is `Metadata => Resource[F, A]` instead of `Metadata => F[A]`. 

The motivation here is to propagate spans for tracing. For example, the library `Natchez` allows a span to propagate from one machine to another by converting a span into a kernel, which is just a collection of http headers (see [docs](https://tpolecat.github.io/natchez/reference/kernels.html)). On the server-side, the trace can be continued by extracting the kernel and creating a `Resource[F, Span[F]]`:
```
def mkCtx[F[_]](m: Metadata): Resource[F, Span[F]] = 
  for {
    ep <- entryPoint[F]
    kern = metadataToKernel(m)
    span <- ep.continue("span name", kern)
  } yield span
```
The "release" method for this resource is how the span gets sent back to the collector, so it's important that the resource isn't released until after the service call has completed (we can't just call `_.use(_.pure[F])`). Currently, the generated code for `serviceBinding` implements each service method as `(r, m) => mkCtx(m).flatMap(serviceImpl.methodName(r, _))` (for non-streaming methods). This implementation doesn't allow a trace to be propagated without manually editing each service method. The generated `serviceBindingResource` (added in this PR) gives the alternate implementation `(r, m) => mkCtx(m).use(serviceImpl.methodName(r, _))`, allowing trace propagation without additional code.