### PR TITLE
add scala 2.13 compatibility for fs2-grpc-codegen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val codegen = project
   .settings(
     name := "fs2-grpc-codegen",
     scalaVersion := Scala212,
-    crossScalaVersions := List(Scala212),
+    crossScalaVersions := List(Scala212, Scala213),
     libraryDependencies += scalaPbCompiler
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,7 @@ inThisBuild(
   )
 )
 
-//
-val projects: Seq[ProjectReference] =
+lazy val projects =
   runtime.projectRefs ++ codegen.projectRefs ++ e2e.projectRefs ++ List(plugin.project, protocGen.agg.project)
 lazy val root = (project in file("."))
   .enablePlugins(BuildInfoPlugin, NoPublishPlugin)

--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2CodeGenerator.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2CodeGenerator.scala
@@ -27,7 +27,7 @@ import com.google.protobuf.compiler.PluginProtos
 import protocgen.{CodeGenApp, CodeGenRequest, CodeGenResponse}
 import scalapb.compiler.{DescriptorImplicits, FunctionalPrinter, GeneratorParams}
 import scalapb.options.Scalapb
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 final case class Fs2Params(serviceSuffix: String = "Fs2Grpc")
 
@@ -47,7 +47,7 @@ object Fs2CodeGenerator extends CodeGenApp {
       b.setName(file.scalaDirectory + "/" + service.name + s"${fs2params.serviceSuffix}.scala")
       b.setContent(code)
       b.build
-    }
+    }.toSeq
   }
 
   private def parseParameters(params: String): Either[String, (GeneratorParams, Fs2Params)] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.16")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.0")
+
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6") // Because sbt-protoc-gen-project brings in 1.0.4


### PR DESCRIPTION
I'm using the `scala_proto_library` rule from [bazelbuild/rules_scala](https://github.com/bazelbuild/rules_scala) to generate gRPC stubs with a scala 2.13 based toolchain.

This pull request adds 2.13 cross-building to `fs2-grpc-codegen` along with the minimal set of changes to Fs2CodeGenerator for compatibility.

I see a version of this was attempted in https://github.com/typelevel/fs2-grpc/pull/352, hopefully this gives some further motivation for doing it.

note: although this worked in my bazel project i think this may fail CI with https://gist.github.com/mackenziestarr/7f01eb8bb5991948d7da79c26207790e

I am not very experienced with sbt but it may be because that these plugin dependencies still use 2.12 during the codegen step
https://github.com/typelevel/fs2-grpc/blob/66223210ea5cd27a8629ec47a8d76e7255a7b41b/project/plugins.sbt#L6-L7

Thanks in advance for looking,
Mackenzie