### PR TITLE
runtime: change when dispatcher shuts down in fs2grpc suite

### DIFF
--- a/runtime/src/test/scala/Fs2GrpcSuite.scala
+++ b/runtime/src/test/scala/Fs2GrpcSuite.scala
@@ -74,8 +74,8 @@ class Fs2GrpcSuite extends CatsEffectSuite with CatsEffectFunFixtures {
       }
 
       body(ec, r, fakeDispatcher)
-      shutdown.unsafeRunAndForget()
       ec.tickAll()
+      shutdown.unsafeRunAndForget()
     }
   }
 }


### PR DESCRIPTION
 - allow test context running to completion before invoking dispatcher shutdown. This should make tests be less brittle wrt. races that cause tests to fail.