### PR TITLE
StreamOutput: replace Stream-evalMap with foreach

### DIFF
--- a/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/Fs2ServerCallListener.scala
@@ -52,7 +52,7 @@ private[server] trait Fs2ServerCallListener[F[_], G[_], Request, Response] {
   private def handleUnaryResponse(headers: Metadata, response: F[Response])(implicit F: Sync[F]): F[Unit] =
     call.sendHeaders(headers) *> call.request(1) *> response >>= call.sendSingleMessage
 
-  private def handleStreamResponse(headers: Metadata, sendResponse: Stream[F, Unit])(implicit F: Sync[F]): F[Unit] =
+  private def handleStreamResponse(headers: Metadata, sendResponse: Stream[F, Nothing])(implicit F: Sync[F]): F[Unit] =
     call.sendHeaders(headers) *> call.request(1) *> sendResponse.compile.drain
 
   private def unsafeRun(f: F[Unit])(implicit F: Async[F]): Unit = {

--- a/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
+++ b/runtime/src/main/scala/fs2/grpc/shared/StreamOutput.scala
@@ -33,7 +33,7 @@ private[grpc] trait StreamOutput[F[_], T] {
 
   def onReadySync(dispatcher: Dispatcher[F]): SyncIO[Unit] = SyncIO.delay(dispatcher.unsafeRunSync(onReady))
 
-  def writeStream(s: Stream[F, T]): Stream[F, Unit]
+  def writeStream(s: Stream[F, T]): Stream[F, Nothing]
 }
 
 private[grpc] object StreamOutput {
@@ -70,7 +70,7 @@ private[grpc] class StreamOutputImpl[F[_], T](
     extends StreamOutput[F, T] {
   override def onReady: F[Unit] = readyCountRef.update(_ + 1L)
 
-  override def writeStream(s: Stream[F, T]): Stream[F, Unit] = s.evalMap(sendWhenReady)
+  override def writeStream(s: Stream[F, T]): Stream[F, Nothing] = s.foreach(sendWhenReady)
 
   private def sendWhenReady(msg: T): F[Unit] = {
     val send = sendMessage(msg)


### PR DESCRIPTION
The "foreach" method is slightly better performing and simpler than the `evalMap` method. Since this is an internal FS2-GRPC method and the results never use the emitted unit values, we can replace it.