### PR TITLE
Add service descriptor to code generator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ inThisBuild(
     mimaBinaryIssueFilters ++= Seq(
       // API that is not extended by end-users
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.mkClient"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.serviceDescriptor"),
       // package private APIs
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.client.StreamIngest.create"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.server.Fs2StreamServerCallListener*"),

--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2AbstractServicePrinter.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2AbstractServicePrinter.scala
@@ -107,12 +107,20 @@ abstract class Fs2AbstractServicePrinter extends Fs2ServicePrinter {
 
   private[this] def serviceObject: PrinterEndo =
     _.add(s"object $serviceNameFs2 extends $Companion[$serviceNameFs2] {").indent.newline
+      .call(serviceDescriptor)
+      .newline
       .call(serviceClient)
       .newline
       .call(serviceBinding)
       .outdent
       .newline
       .add("}")
+
+  private[this] def serviceDescriptor: PrinterEndo = {
+    _.add(
+      s"def serviceDescriptor: ${Fs2AbstractServicePrinter.constants.ServiceDescriptor} = ${service.grpcDescriptor.fullName}"
+    )
+  }
 
   private[this] def serviceClient: PrinterEndo = {
     _.add(
@@ -170,6 +178,7 @@ object Fs2AbstractServicePrinter {
     val ServerServiceDefinition = s"$grpcPkg.ServerServiceDefinition"
     val Channel = s"$grpcPkg.Channel"
     val Metadata = s"$grpcPkg.Metadata"
+    val ServiceDescriptor = s"$grpcPkg.ServiceDescriptor"
 
   }
 

--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -11,6 +11,8 @@ trait TestServiceFs2Grpc[F[_], A] {
 
 object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2Grpc] {
   
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  
   def mkClient[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMetadata: A => F[_root_.io.grpc.Metadata], clientOptions: _root_.fs2.grpc.client.ClientOptions): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
     def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage] = {
       mkMetadata(ctx).flatMap { m =>

--- a/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
@@ -11,6 +11,8 @@ trait TestServiceFs2GrpcTrailers[F[_], A] {
 
 object TestServiceFs2GrpcTrailers extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcTrailers] {
   
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  
   def mkClient[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMetadata: A => F[_root_.io.grpc.Metadata], clientOptions: _root_.fs2.grpc.client.ClientOptions): TestServiceFs2GrpcTrailers[F, A] = new TestServiceFs2GrpcTrailers[F, A] {
     def noStreaming(request: hello.world.TestMessage, ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] = {
       mkMetadata(ctx).flatMap { m =>

--- a/runtime/src/main/scala/fs2/grpc/GeneratedCompanion.scala
+++ b/runtime/src/main/scala/fs2/grpc/GeneratedCompanion.scala
@@ -33,6 +33,10 @@ trait GeneratedCompanion[Service[*[_], _]] {
 
   implicit final def serviceCompanion: GeneratedCompanion[Service] = this
 
+/// === ServiceDescriptor ==============================================================================================
+
+  def serviceDescriptor: ServiceDescriptor
+
 ///=== Client ==========================================================================================================
 
   def mkClient[F[_]: Async, A](


### PR DESCRIPTION
This PR adds service descriptor in the code generator for gRPC services.

The service descriptor is useful to get general information about the service. For instance, in our case, we use the name to load the service's configuration.