### PR TITLE
build: make sbt clean before tlCiRelease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
       - name: Publish
-        run: sbt tlCiRelease
+        run: sbt clean tlCiRelease
 
   validate-steward:
     name: Validate Steward Config

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,9 @@ inThisBuild(
     githubWorkflowJavaVersions := Seq(
       JavaSpec.temurin("8"),
       JavaSpec.temurin("17")
+    ),
+    githubWorkflowPublish := Seq(
+      WorkflowStep.Sbt(List("clean", "tlCiRelease"), name = Some("Publish"))
     )
   ) ++ List(
     mimaBinaryIssueFilters ++= Seq(


### PR DESCRIPTION
 - Somehow Scala 2 artifacts contain tasty files and this is an attempt to fix that.