### PR TITLE
668 aspect oriented middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,8 @@ inThisBuild(
   ) ++ List(
     mimaBinaryIssueFilters ++= Seq(
       // API that is not extended by end-users
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.mkClient"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.mkClientFull"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.serviceBindingFull"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.grpc.GeneratedCompanion.serviceDescriptor"),
       // package private APIs
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.client.StreamIngest.create"),
@@ -138,7 +139,13 @@ lazy val e2e = (projectMatrix in file("e2e"))
   .settings(
     codeGenClasspath := (codeGenJVM212 / Compile / fullClasspath).value,
     libraryDependencies := Nil,
-    libraryDependencies ++= List(scalaPbGrpcRuntime, scalaPbRuntime, scalaPbRuntime % "protobuf", ceMunit % Test),
+    libraryDependencies ++= List(
+      scalaPbGrpcRuntime,
+      scalaPbRuntime,
+      scalaPbRuntime % "protobuf",
+      ceMunit % Test,
+      "io.grpc" % "grpc-inprocess" % versions.grpc % Test
+    ),
     Compile / PB.targets := Seq(
       scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
       genModule(codegenFullName + "$") -> (Compile / sourceManaged).value / "fs2-grpc"

--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -24,36 +24,86 @@ object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestService
   
   def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
   
-  def mkClient[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMetadata: A => F[_root_.io.grpc.Metadata], clientOptions: _root_.fs2.grpc.client.ClientOptions): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
-    def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage] = {
-      mkMetadata(ctx).flatMap { m =>
-        _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(request, m))
-      }
-    }
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage] = {
-      mkMetadata(ctx).flatMap { m =>
-        _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(request, m))
-      }
-    }
-    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] = {
-      _root_.fs2.Stream.eval(mkMetadata(ctx)).flatMap { m =>
-        _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(request, m))
-      }
-    }
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] = {
-      _root_.fs2.Stream.eval(mkMetadata(ctx)).flatMap { m =>
-        _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(request, m))
-      }
-    }
+  def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    channel: _root_.io.grpc.Channel,
+    clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
+    clientOptions: _root_.fs2.grpc.client.ClientOptions
+  ): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
+    def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage] =
+      clientAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
+      )
+    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage] =
+      clientAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
+      )
+    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+      )
+    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+      )
   }
   
-  protected def serviceBinding[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], serviceImpl: TestServiceFs2Grpc[F, A], mkCtx: _root_.io.grpc.Metadata => F[A], serverOptions: _root_.fs2.grpc.server.ServerOptions): _root_.io.grpc.ServerServiceDefinition = {
+  protected def serviceBindingFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    serviceImpl: TestServiceFs2Grpc[F, A],
+    serviceAspect: _root_.fs2.grpc.server.ServiceAspect[F, G, A],
+    serverOptions: _root_.fs2.grpc.server.ServerOptions
+  ) = {
     _root_.io.grpc.ServerServiceDefinition
       .builder(hello.world.TestServiceGrpc.SERVICE)
-      .addMethod(hello.world.TestServiceGrpc.METHOD_NO_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.noStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.clientStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.serverStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.bothStreaming(r, _))))
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+            r,
+            (r, m) => serviceImpl.noStreaming(r, m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+            r,
+            (r, m) => serviceImpl.clientStreaming(r, m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+            r,
+            (r, m) => serviceImpl.serverStreaming(r, m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+            r,
+            (r, m) => serviceImpl.bothStreaming(r, m)
+          )
+        }
+      )
       .build()
   }
 

--- a/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
@@ -24,36 +24,86 @@ object TestServiceFs2GrpcTrailers extends _root_.fs2.grpc.GeneratedCompanion[Tes
   
   def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
   
-  def mkClient[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMetadata: A => F[_root_.io.grpc.Metadata], clientOptions: _root_.fs2.grpc.client.ClientOptions): TestServiceFs2GrpcTrailers[F, A] = new TestServiceFs2GrpcTrailers[F, A] {
-    def noStreaming(request: hello.world.TestMessage, ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] = {
-      mkMetadata(ctx).flatMap { m =>
-        _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(request, m))
-      }
-    }
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] = {
-      mkMetadata(ctx).flatMap { m =>
-        _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(request, m))
-      }
-    }
-    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] = {
-      _root_.fs2.Stream.eval(mkMetadata(ctx)).flatMap { m =>
-        _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(request, m))
-      }
-    }
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] = {
-      _root_.fs2.Stream.eval(mkMetadata(ctx)).flatMap { m =>
-        _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(request, m))
-      }
-    }
+  def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    channel: _root_.io.grpc.Channel,
+    clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
+    clientOptions: _root_.fs2.grpc.client.ClientOptions
+  ): TestServiceFs2GrpcTrailers[F, A] = new TestServiceFs2GrpcTrailers[F, A] {
+    def noStreaming(request: hello.world.TestMessage, ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
+      )
+    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
+      )
+    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+      )
+    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+      )
   }
   
-  protected def serviceBinding[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], serviceImpl: TestServiceFs2GrpcTrailers[F, A], mkCtx: _root_.io.grpc.Metadata => F[A], serverOptions: _root_.fs2.grpc.server.ServerOptions): _root_.io.grpc.ServerServiceDefinition = {
+  protected def serviceBindingFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    serviceImpl: TestServiceFs2GrpcTrailers[F, A],
+    serviceAspect: _root_.fs2.grpc.server.ServiceAspect[F, G, A],
+    serverOptions: _root_.fs2.grpc.server.ServerOptions
+  ) = {
     _root_.io.grpc.ServerServiceDefinition
       .builder(hello.world.TestServiceGrpc.SERVICE)
-      .addMethod(hello.world.TestServiceGrpc.METHOD_NO_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.noStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.clientStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.serverStreaming(r, _))))
-      .addMethod(hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.bothStreaming(r, _))))
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+            r,
+            (r, m) => serviceImpl.noStreaming(r, m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+            r,
+            (r, m) => serviceImpl.clientStreaming(r, m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+            r,
+            (r, m) => serviceImpl.serverStreaming(r, m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+            r,
+            (r, m) => serviceImpl.bothStreaming(r, m)
+          )
+        }
+      )
       .build()
   }
 

--- a/e2e/src/test/scala/fs2/grpc/e2e/AspectSpec.scala
+++ b/e2e/src/test/scala/fs2/grpc/e2e/AspectSpec.scala
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.e2e
+
+import hello.world._
+import io.grpc.inprocess._
+import cats.effect._
+import cats.implicits._
+import munit._
+import cats.effect.std.UUIDGen
+import io.grpc._
+import scala.jdk.CollectionConverters._
+import cats.effect.std.Dispatcher
+import fs2.grpc.server._
+import fs2.grpc.client._
+import fs2.grpc.syntax.all._
+import cats.data._
+import cats._
+import cats.effect.std.SecureRandom
+
+class AspectSpec extends CatsEffectSuite with CatsEffectFunFixtures {
+  def startServices[F[_]](id: String)(xs: ServerServiceDefinition*)(implicit F: Sync[F]): Resource[F, Server] =
+    InProcessServerBuilder
+      .forName(id.toString())
+      .addServices(xs.toList.asJava)
+      .resource[F]
+      .evalTap(s => F.delay(s.start()))
+
+  def testConnection[F[_]: SecureRandom: Async, G[_], A, B](
+      service: TestServiceFs2Grpc[G, A],
+      serviceAspect: ServiceAspect[G, F, A],
+      clientAspect: ClientAspect[G, F, B]
+  ): Resource[F, TestServiceFs2Grpc[G, B]] =
+    Dispatcher.parallel[F].flatMap { d =>
+      Resource.eval(UUIDGen.fromSecureRandom[F].randomUUID).flatMap { id =>
+        startServices[F](id.toString())(
+          TestServiceFs2Grpc.serviceFull[G, F, A](
+            d,
+            service,
+            serviceAspect,
+            ServerOptions.default
+          )
+        ) >> InProcessChannelBuilder.forName(id.toString()).usePlaintext().resource[F].map { conn =>
+          TestServiceFs2Grpc.mkClientFull[G, F, B](
+            d,
+            conn,
+            clientAspect,
+            ClientOptions.default
+          )
+        }
+      }
+    }
+
+  test("tracing requests should work as expected") {
+    case class TracingKey(value: String)
+    case class Span(name: String, parent: Either[Span, Option[TracingKey]]) {
+      def traceKey: Option[TracingKey] = parent.leftMap(_.traceKey).merge
+    }
+    case class SpanInfo(span: Span, messages: List[String])
+    type WriteSpan[A] = WriterT[IO, List[SpanInfo], A]
+    type Traced[A] = Kleisli[WriteSpan, Span, A]
+    val Traced: Monad[Traced] = Monad[Traced]
+    val liftK: IO ~> Traced = WriterT.liftK[IO, List[SpanInfo]] andThen Kleisli.liftK[WriteSpan, Span]
+    def span[A](name: String)(fa: Traced[A]): Traced[A] =
+      fa.local[Span](parent => Span(name, Left(parent)))
+
+    def spanStream[A](name: String)(fa: fs2.Stream[Traced, A]): fs2.Stream[Traced, A] = {
+      val current: Traced[Span] = Kleisli.ask
+      fs2.Stream.eval(current).flatMap { parent =>
+        fa.translate(new (Traced ~> Traced) {
+          def apply[B](fa: Traced[B]): Traced[B] =
+            Kleisli.local((_: Span) => Span(name, Left(parent)))(fa)
+        })
+      }
+    }
+
+    def tell(spanInfos: List[SpanInfo]): Traced[Unit] =
+      Kleisli.liftF(WriterT.tell[IO, List[SpanInfo]](spanInfos))
+
+    def log(msgs: String*): Traced[Unit] = Kleisli.ask[WriteSpan, Span].flatMap { current =>
+      tell(List(SpanInfo(current, msgs.toList)))
+    }
+
+    val tracingHeaderKey = Metadata.Key.of("TRACE_KEY", Metadata.ASCII_STRING_MARSHALLER)
+    def getTraceHeader(ctx: Metadata): Option[TracingKey] =
+      Option(ctx.get(tracingHeaderKey)).map(TracingKey(_))
+
+    def serializeTraceHeader(key: TracingKey): Metadata = {
+      val m = new Metadata
+      m.put(tracingHeaderKey, key.value)
+      m
+    }
+
+    def getTracingHeader: Traced[Metadata] =
+      Kleisli.ask[WriteSpan, Span].map { span =>
+        span.traceKey.map(serializeTraceHeader).getOrElse(new Metadata)
+      }
+
+    val service = new TestServiceFs2Grpc[Traced, Metadata] {
+      override def noStreaming(request: TestMessage, ctx: Metadata): Traced[TestMessage] =
+        span("noStreaming") {
+          log("noStreaming") >>
+            Traced.pure(TestMessage.defaultInstance)
+        }
+
+      override def clientStreaming(request: fs2.Stream[Traced, TestMessage], ctx: Metadata): Traced[TestMessage] =
+        span("clientStreaming") {
+          log("clientStreaming") >>
+            request.compile.last.map(_.getOrElse(TestMessage.defaultInstance))
+        }
+
+      override def serverStreaming(request: TestMessage, ctx: Metadata): fs2.Stream[Traced, TestMessage] =
+        spanStream("serverStreaming") {
+          fs2.Stream(request).repeatN(2).evalTap(_ => log("serverStreaming"))
+        }
+
+      override def bothStreaming(
+          request: fs2.Stream[Traced, TestMessage],
+          ctx: Metadata
+      ): fs2.Stream[Traced, TestMessage] =
+        spanStream("bothStreaming") {
+          request.evalTap(_ => log("bothStreaming"))
+        }
+    }
+
+    IO.ref(List.empty[SpanInfo]).flatMap { state =>
+      def runRootTrace[A](cctx: ServiceCallContext[?, ?])(fa: Traced[A]): IO[A] = {
+        val root = Span(cctx.methodDescriptor.getFullMethodName(), Right(getTraceHeader(cctx.metadata)))
+        fa.run(root).run.flatMap { case (xs, a) =>
+          state.update(_ ++ xs) as a
+        }
+      }
+
+      def runRootTraceStreamed[A](cctx: ServiceCallContext[?, ?])(fa: fs2.Stream[Traced, A]): fs2.Stream[IO, A] =
+        fa.translate(new (Traced ~> IO) {
+          def apply[B](fa: Traced[B]): IO[B] = runRootTrace(cctx)(fa)
+        })
+
+      val tracingServiceAspect = new ServiceAspect[Traced, IO, Metadata] {
+        override def visitUnaryToUnaryCallTrailers[Req, Res](
+            callCtx: ServiceCallContext[Req, Res],
+            req: Req,
+            run: (Req, Metadata) => Traced[(Res, Metadata)]
+        ): IO[(Res, Metadata)] = ???
+
+        override def visitStreamingToUnaryCallTrailers[Req, Res](
+            callCtx: ServiceCallContext[Req, Res],
+            req: fs2.Stream[IO, Req],
+            run: (fs2.Stream[Traced, Req], Metadata) => Traced[(Res, Metadata)]
+        ): IO[(Res, Metadata)] = ???
+
+        override def visitUnaryToUnaryCall[Req, Res](
+            callCtx: ServiceCallContext[Req, Res],
+            req: Req,
+            run: (Req, Metadata) => Traced[Res]
+        ): IO[Res] = runRootTrace(callCtx)(run(req, callCtx.metadata))
+
+        override def visitUnaryToStreamingCall[Req, Res](
+            callCtx: ServiceCallContext[Req, Res],
+            req: Req,
+            run: (Req, Metadata) => fs2.Stream[Traced, Res]
+        ): fs2.Stream[IO, Res] = runRootTraceStreamed(callCtx)(run(req, callCtx.metadata))
+
+        override def visitStreamingToUnaryCall[Req, Res](
+            callCtx: ServiceCallContext[Req, Res],
+            req: fs2.Stream[IO, Req],
+            run: (fs2.Stream[Traced, Req], Metadata) => Traced[Res]
+        ): IO[Res] = runRootTrace(callCtx)(run(req.translate(liftK), callCtx.metadata))
+
+        override def visitStreamingToStreamingCall[Req, Res](
+            callCtx: ServiceCallContext[Req, Res],
+            req: fs2.Stream[IO, Req],
+            run: (fs2.Stream[Traced, Req], Metadata) => fs2.Stream[Traced, Res]
+        ): fs2.Stream[IO, Res] = runRootTraceStreamed(callCtx)(run(req.translate(liftK), callCtx.metadata))
+      }
+
+      val tracingClientAspect = new ClientAspect[Traced, IO, Unit] {
+        override def visitUnaryToUnaryCallTrailers[Req, Res](
+            callCtx: ClientCallContext[Req, Res, Unit],
+            req: Req,
+            run: (Req, Metadata) => IO[(Res, Metadata)]
+        ): Traced[(Res, Metadata)] = ???
+
+        override def visitStreamingToUnaryCallTrailers[Req, Res](
+            callCtx: ClientCallContext[Req, Res, Unit],
+            req: fs2.Stream[Traced, Req],
+            run: (fs2.Stream[IO, Req], Metadata) => IO[(Res, Metadata)]
+        ): Traced[(Res, Metadata)] = ???
+
+        override def visitUnaryToUnaryCall[Req, Res](
+            callCtx: ClientCallContext[Req, Res, Unit],
+            req: Req,
+            run: (Req, Metadata) => IO[Res]
+        ): Traced[Res] =
+          getTracingHeader.flatMap(md => liftK(run(req, md)))
+
+        override def visitUnaryToStreamingCall[Req, Res](
+            callCtx: ClientCallContext[Req, Res, Unit],
+            req: Req,
+            run: (Req, Metadata) => fs2.Stream[IO, Res]
+        ): fs2.Stream[Traced, Res] =
+          fs2.Stream.eval(getTracingHeader).flatMap(md => run(req, md).translate(liftK))
+
+        override def visitStreamingToUnaryCall[Req, Res](
+            callCtx: ClientCallContext[Req, Res, Unit],
+            req: fs2.Stream[Traced, Req],
+            run: (fs2.Stream[IO, Req], Metadata) => IO[Res]
+        ): Traced[Res] = Kleisli.ask[WriteSpan, Span].flatMap { parent =>
+          getTracingHeader.flatMap { md =>
+            liftK(IO.ref(List.empty[SpanInfo])).flatMap { state =>
+              val req2 = req.translate(new (Traced ~> IO) {
+                def apply[A](fa: Traced[A]): IO[A] =
+                  fa.run(parent).run.flatMap { case (xs, a) =>
+                    state.update(_ ++ xs) as a
+                  }
+              })
+              liftK(run(req2, md)) <* (liftK(state.get) >>= tell)
+            }
+          }
+        }
+
+        override def visitStreamingToStreamingCall[Req, Res](
+            callCtx: ClientCallContext[Req, Res, Unit],
+            req: fs2.Stream[Traced, Req],
+            run: (fs2.Stream[IO, Req], Metadata) => fs2.Stream[IO, Res]
+        ): fs2.Stream[Traced, Res] =
+          fs2.Stream.eval(Kleisli.ask[WriteSpan, Span]).flatMap { parent =>
+            fs2.Stream.eval(getTracingHeader).flatMap { md =>
+              fs2.Stream.eval(liftK(IO.ref(List.empty[SpanInfo]))).flatMap { state =>
+                val req2 = req.translate(new (Traced ~> IO) {
+                  def apply[A](fa: Traced[A]): IO[A] =
+                    fa.run(parent).run.flatMap { case (xs, a) =>
+                      state.update(_ ++ xs) as a
+                    }
+                })
+                run(req2, md).translate(liftK) ++ fs2.Stream.exec((liftK(state.get) >>= tell))
+              }
+            }
+          }
+      }
+
+      testConnection[IO, Traced, Metadata, Unit](
+        service,
+        tracingServiceAspect,
+        tracingClientAspect
+      ).use { (client: TestServiceFs2Grpc[Traced, Unit]) =>
+        def testWithKey(rootKey: Option[TracingKey] = None) = {
+          def trackServer[A](fa: IO[A]): IO[List[SpanInfo]] =
+            state.set(Nil) >> fa >> state.get
+
+          def trackClient[A](traced: Traced[A]): IO[List[SpanInfo]] =
+            traced.run(Span("root", Right(rootKey))).written
+
+          def trackAndAssertServer[A](name: String, n: Int)(fa: IO[A])(implicit loc: Location): IO[Unit] =
+            trackServer(fa).map { serverInfos =>
+              assertEquals(serverInfos.size, n)
+              serverInfos.foreach { si =>
+                assertEquals(si.span.name, name)
+                assert(clue(si.span.parent).isLeft, "is child")
+                assertEquals(si.messages, List(name))
+              }
+            }
+
+          def trackAndAssertClient[A](name: String, n: Int)(fa: Traced[A])(implicit loc: Location): IO[Unit] =
+            trackClient(fa).map { clientInfos =>
+              assertEquals(clientInfos.size, n)
+              clientInfos.foreach { ci =>
+                assertEquals(ci.span.name, s"client-${name}")
+                assert(clue(ci.span.parent).isLeft, "is child")
+                assertEquals(ci.messages, List(s"client-${name}"))
+              }
+            }
+
+          val noStreaming = trackAndAssertServer("noStreaming", 1) {
+            trackAndAssertClient("noStreaming", 1) {
+              span("client-noStreaming") {
+                log("client-noStreaming") >>
+                  client.noStreaming(TestMessage.defaultInstance, ())
+              }
+            }
+          }
+
+          val clientStreaming = trackAndAssertServer("clientStreaming", 1) {
+            trackAndAssertClient("clientStreaming", 2) {
+              val req = fs2.Stream
+                .eval {
+                  span("client-clientStreaming") {
+                    log("client-clientStreaming").as(TestMessage.defaultInstance)
+                  }
+                }
+                .repeatN(2)
+
+              client.clientStreaming(req, ())
+            }
+          }
+
+          val serverStreaming = trackAndAssertServer("serverStreaming", 2) {
+            trackAndAssertClient("serverStreaming", 1) {
+              span("client-serverStreaming") {
+                log("client-serverStreaming") >>
+                  client.serverStreaming(TestMessage.defaultInstance, ()).compile.drain
+              }
+            }
+          }
+
+          val bothStreaming = trackAndAssertServer("bothStreaming", 2) {
+            trackAndAssertClient("bothStreaming", 2) {
+              val req = fs2.Stream
+                .eval {
+                  span("client-bothStreaming") {
+                    log("client-bothStreaming").as(TestMessage.defaultInstance)
+                  }
+                }
+                .repeatN(2)
+
+              client.bothStreaming(req, ()).compile.drain
+            }
+          }
+
+          noStreaming >> clientStreaming >> serverStreaming >> bothStreaming
+        }
+
+        testWithKey() >> testWithKey(Some(TracingKey("my_tracing_key")))
+      }
+    }
+  }
+}

--- a/runtime/src/main/scala/fs2/grpc/client/ClientAspect.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/ClientAspect.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.client
+
+import io.grpc._
+import cats._
+import cats.syntax.all._
+import fs2.Stream
+
+final case class ClientCallContext[Req, Res, A](
+    ctx: A,
+    methodDescriptor: MethodDescriptor[Req, Res]
+)
+
+trait ClientAspect[F[_], G[_], A] { self =>
+  def visitUnaryToUnaryCall[Req, Res](
+      callCtx: ClientCallContext[Req, Res, A],
+      req: Req,
+      run: (Req, Metadata) => G[Res]
+  ): F[Res]
+
+  def visitUnaryToStreamingCall[Req, Res](
+      callCtx: ClientCallContext[Req, Res, A],
+      req: Req,
+      run: (Req, Metadata) => Stream[G, Res]
+  ): Stream[F, Res]
+
+  def visitStreamingToUnaryCall[Req, Res](
+      callCtx: ClientCallContext[Req, Res, A],
+      req: Stream[F, Req],
+      run: (Stream[G, Req], Metadata) => G[Res]
+  ): F[Res]
+
+  def visitStreamingToStreamingCall[Req, Res](
+      callCtx: ClientCallContext[Req, Res, A],
+      req: Stream[F, Req],
+      run: (Stream[G, Req], Metadata) => Stream[G, Res]
+  ): Stream[F, Res]
+
+  def visitUnaryToUnaryCallTrailers[Req, Res](
+      callCtx: ClientCallContext[Req, Res, A],
+      req: Req,
+      run: (Req, Metadata) => G[(Res, Metadata)]
+  ): F[(Res, Metadata)]
+
+  def visitStreamingToUnaryCallTrailers[Req, Res](
+      callCtx: ClientCallContext[Req, Res, A],
+      req: Stream[F, Req],
+      run: (Stream[G, Req], Metadata) => G[(Res, Metadata)]
+  ): F[(Res, Metadata)]
+
+  def contraModify[B](f: B => F[A])(implicit F: Monad[F]): ClientAspect[F, G, B] =
+    new ClientAspect[F, G, B] {
+      def modCtx[Req, Res](ccc: ClientCallContext[Req, Res, B]): F[ClientCallContext[Req, Res, A]] =
+        f(ccc.ctx).map(a => ccc.copy(ctx = a))
+
+      override def visitUnaryToUnaryCall[Req, Res](
+          callCtx: ClientCallContext[Req, Res, B],
+          req: Req,
+          run: (Req, Metadata) => G[Res]
+      ): F[Res] =
+        modCtx(callCtx).flatMap(self.visitUnaryToUnaryCall(_, req, run))
+
+      override def visitUnaryToStreamingCall[Req, Res](
+          callCtx: ClientCallContext[Req, Res, B],
+          req: Req,
+          run: (Req, Metadata) => Stream[G, Res]
+      ): Stream[F, Res] =
+        Stream.eval(modCtx(callCtx)).flatMap(self.visitUnaryToStreamingCall(_, req, run))
+
+      override def visitStreamingToUnaryCall[Req, Res](
+          callCtx: ClientCallContext[Req, Res, B],
+          req: Stream[F, Req],
+          run: (Stream[G, Req], Metadata) => G[Res]
+      ): F[Res] =
+        modCtx(callCtx).flatMap(self.visitStreamingToUnaryCall(_, req, run))
+
+      override def visitStreamingToStreamingCall[Req, Res](
+          callCtx: ClientCallContext[Req, Res, B],
+          req: Stream[F, Req],
+          run: (Stream[G, Req], Metadata) => Stream[G, Res]
+      ): Stream[F, Res] =
+        Stream.eval(modCtx(callCtx)).flatMap(self.visitStreamingToStreamingCall(_, req, run))
+
+      override def visitUnaryToUnaryCallTrailers[Req, Res](
+          callCtx: ClientCallContext[Req, Res, B],
+          req: Req,
+          run: (Req, Metadata) => G[(Res, Metadata)]
+      ): F[(Res, Metadata)] =
+        modCtx(callCtx).flatMap(self.visitUnaryToUnaryCallTrailers(_, req, run))
+
+      override def visitStreamingToUnaryCallTrailers[Req, Res](
+          callCtx: ClientCallContext[Req, Res, B],
+          req: Stream[F, Req],
+          run: (Stream[G, Req], Metadata) => G[(Res, Metadata)]
+      ): F[(Res, Metadata)] =
+        modCtx(callCtx).flatMap(self.visitStreamingToUnaryCallTrailers(_, req, run))
+
+    }
+}
+
+object ClientAspect {
+  trait Default[F[_]] extends ClientAspect[F, F, Metadata] {
+    override def visitUnaryToUnaryCall[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Metadata],
+        req: Req,
+        run: (Req, Metadata) => F[Res]
+    ): F[Res] = run(req, callCtx.ctx)
+
+    override def visitUnaryToStreamingCall[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Metadata],
+        req: Req,
+        run: (Req, Metadata) => Stream[F, Res]
+    ): Stream[F, Res] = run(req, callCtx.ctx)
+
+    override def visitStreamingToUnaryCall[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Metadata],
+        req: Stream[F, Req],
+        run: (Stream[F, Req], Metadata) => F[Res]
+    ): F[Res] = run(req, callCtx.ctx)
+
+    override def visitStreamingToStreamingCall[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Metadata],
+        req: Stream[F, Req],
+        run: (Stream[F, Req], Metadata) => Stream[F, Res]
+    ): Stream[F, Res] = run(req, callCtx.ctx)
+
+    override def visitUnaryToUnaryCallTrailers[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Metadata],
+        req: Req,
+        run: (Req, Metadata) => F[(Res, Metadata)]
+    ): F[(Res, Metadata)] = run(req, callCtx.ctx)
+
+    override def visitStreamingToUnaryCallTrailers[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Metadata],
+        req: Stream[F, Req],
+        run: (Stream[F, Req], Metadata) => F[(Res, Metadata)]
+    ): F[(Res, Metadata)] = run(req, callCtx.ctx)
+  }
+}

--- a/runtime/src/main/scala/fs2/grpc/server/ServiceAspect.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/ServiceAspect.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.server
+
+import io.grpc._
+import cats._
+import cats.syntax.all._
+import fs2.Stream
+
+final case class ServiceCallContext[Req, Res](
+    metadata: Metadata,
+    methodDescriptor: MethodDescriptor[Req, Res]
+)
+
+trait ServiceAspect[F[_], G[_], A] { self =>
+  def visitUnaryToUnaryCall[Req, Res](
+      callCtx: ServiceCallContext[Req, Res],
+      req: Req,
+      run: (Req, A) => F[Res]
+  ): G[Res]
+
+  def visitUnaryToStreamingCall[Req, Res](
+      callCtx: ServiceCallContext[Req, Res],
+      req: Req,
+      run: (Req, A) => fs2.Stream[F, Res]
+  ): fs2.Stream[G, Res]
+
+  def visitStreamingToUnaryCall[Req, Res](
+      callCtx: ServiceCallContext[Req, Res],
+      req: fs2.Stream[G, Req],
+      run: (fs2.Stream[F, Req], A) => F[Res]
+  ): G[Res]
+
+  def visitStreamingToStreamingCall[Req, Res](
+      callCtx: ServiceCallContext[Req, Res],
+      req: fs2.Stream[G, Req],
+      run: (fs2.Stream[F, Req], A) => fs2.Stream[F, Res]
+  ): fs2.Stream[G, Res]
+
+  def visitUnaryToUnaryCallTrailers[Req, Res](
+      callCtx: ServiceCallContext[Req, Res],
+      req: Req,
+      run: (Req, A) => F[(Res, Metadata)]
+  ): G[(Res, Metadata)]
+
+  def visitStreamingToUnaryCallTrailers[Req, Res](
+      callCtx: ServiceCallContext[Req, Res],
+      req: fs2.Stream[G, Req],
+      run: (fs2.Stream[F, Req], A) => F[(Res, Metadata)]
+  ): G[(Res, Metadata)]
+
+  def modify[B](f: A => F[B])(implicit F: Monad[F]): ServiceAspect[F, G, B] =
+    new ServiceAspect[F, G, B] {
+      override def visitUnaryToUnaryCall[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Req,
+          request: (Req, B) => F[Res]
+      ): G[Res] =
+        self.visitUnaryToUnaryCall[Req, Res](
+          callCtx,
+          req,
+          (req, a) => f(a).flatMap(request(req, _))
+        )
+
+      override def visitUnaryToStreamingCall[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Req,
+          request: (Req, B) => Stream[F, Res]
+      ): Stream[G, Res] =
+        self.visitUnaryToStreamingCall[Req, Res](
+          callCtx,
+          req,
+          (req, a) => fs2.Stream.eval(f(a)).flatMap(request(req, _))
+        )
+
+      override def visitStreamingToUnaryCall[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: fs2.Stream[G, Req],
+          request: (Stream[F, Req], B) => F[Res]
+      ): G[Res] =
+        self.visitStreamingToUnaryCall[Req, Res](
+          callCtx,
+          req,
+          (req, a) => f(a).flatMap(request(req, _))
+        )
+
+      override def visitStreamingToStreamingCall[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: fs2.Stream[G, Req],
+          request: (Stream[F, Req], B) => Stream[F, Res]
+      ): Stream[G, Res] =
+        self.visitStreamingToStreamingCall[Req, Res](
+          callCtx,
+          req,
+          (req, a) => fs2.Stream.eval(f(a)).flatMap(request(req, _))
+        )
+
+      override def visitUnaryToUnaryCallTrailers[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Req,
+          request: (Req, B) => F[(Res, Metadata)]
+      ): G[(Res, Metadata)] =
+        self.visitUnaryToUnaryCallTrailers[Req, Res](
+          callCtx,
+          req,
+          (req, a) => f(a).flatMap(request(req, _))
+        )
+
+      override def visitStreamingToUnaryCallTrailers[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: fs2.Stream[G, Req],
+          request: (Stream[F, Req], B) => F[(Res, Metadata)]
+      ): G[(Res, Metadata)] =
+        self.visitStreamingToUnaryCallTrailers[Req, Res](
+          callCtx,
+          req,
+          (req, a) => f(a).flatMap(request(req, _))
+        )
+    }
+}
+
+object ServiceAspect {
+  trait Default[F[_]] extends ServiceAspect[F, F, Metadata] {
+    override def visitUnaryToUnaryCall[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Req,
+        request: (Req, Metadata) => F[Res]
+    ): F[Res] = request(req, callCtx.metadata)
+
+    override def visitUnaryToStreamingCall[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Req,
+        request: (Req, Metadata) => Stream[F, Res]
+    ): Stream[F, Res] = request(req, callCtx.metadata)
+
+    override def visitStreamingToUnaryCall[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: fs2.Stream[F, Req],
+        request: (Stream[F, Req], Metadata) => F[Res]
+    ): F[Res] = request(req, callCtx.metadata)
+
+    override def visitStreamingToStreamingCall[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: fs2.Stream[F, Req],
+        request: (Stream[F, Req], Metadata) => Stream[F, Res]
+    ): Stream[F, Res] = request(req, callCtx.metadata)
+
+    override def visitUnaryToUnaryCallTrailers[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Req,
+        request: (Req, Metadata) => F[(Res, Metadata)]
+    ): F[(Res, Metadata)] = request(req, callCtx.metadata)
+
+    override def visitStreamingToUnaryCallTrailers[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: fs2.Stream[F, Req],
+        request: (Stream[F, Req], Metadata) => F[(Res, Metadata)]
+    ): F[(Res, Metadata)] = request(req, callCtx.metadata)
+  }
+}


### PR DESCRIPTION
Initial draft for #668

<details>
  <summary>Example output for TestServiceFs2Grpc</summary>

```scala
package hello.world

import _root_.cats.syntax.all._

trait TestServiceFs2Grpc[F[_], A] {
  def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage]
  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage]
  def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
}

object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2Grpc] {
  
  def mkClientFull[F[_]: _root_.cats.effect.Async, Dom[_], Cod[_], A](
    dispatcher: _root_.cats.effect.std.Dispatcher[F],
    channel: _root_.io.grpc.Channel,
    clientAspect: _root_.fs2.grpc.client.ClientAspect[F, Dom, Cod, A],
    clientOptions: _root_.fs2.grpc.client.ClientOptions
  )(implicit
    dom0: Dom[hello.world.TestMessage],
    cod0: Cod[hello.world.TestMessage]
  ): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
    def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage] =
      clientAspect.visitUnaryToUnary[hello.world.TestMessage, hello.world.TestMessage](
        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, implicitly[Dom[hello.world.TestMessage]], implicitly[Cod[hello.world.TestMessage]]),
        request,
        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
      )
    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage] =
      clientAspect.visitStreamingToUnary[hello.world.TestMessage, hello.world.TestMessage](
        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, implicitly[Dom[hello.world.TestMessage]], implicitly[Cod[hello.world.TestMessage]]),
        request,
        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
      )
    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
      clientAspect.visitUnaryToStreaming[hello.world.TestMessage, hello.world.TestMessage](
        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, implicitly[Dom[hello.world.TestMessage]], implicitly[Cod[hello.world.TestMessage]]),
        request,
        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
      )
    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
      clientAspect.visitStreamingToStreaming[hello.world.TestMessage, hello.world.TestMessage](
        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, implicitly[Dom[hello.world.TestMessage]], implicitly[Cod[hello.world.TestMessage]]),
        request,
        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
      )
  }
  
  def mkClientTrivial[F[_]: _root_.cats.effect.Async, A](
    dispatcher: _root_.cats.effect.std.Dispatcher[F],
    channel: _root_.io.grpc.Channel,
    clientAspect: _root_.fs2.grpc.client.ClientAspect[F, _root_.fs2.grpc.shared.Trivial, _root_.fs2.grpc.shared.Trivial, A],
    clientOptions: _root_.fs2.grpc.client.ClientOptions
  ) = 
    mkClientFull[F, _root_.fs2.grpc.shared.Trivial, _root_.fs2.grpc.shared.Trivial, A](
      dispatcher,
      channel,
      clientAspect,
      clientOptions
    )
  
  protected def serviceBindingFull[F[_]: _root_.cats.effect.Async, Dom[_], Cod[_], A](
    dispatcher: _root_.cats.effect.std.Dispatcher[F],
    serviceImpl: TestServiceFs2Grpc[F, A],
    serviceAspect: _root_.fs2.grpc.server.ServiceAspect[F, Dom, Cod, A],
    serverOptions: _root_.fs2.grpc.server.ServerOptions
  )(implicit
    dom0: Dom[hello.world.TestMessage],
    cod0: Cod[hello.world.TestMessage]
  ) = {
    _root_.io.grpc.ServerServiceDefinition
      .builder(hello.world.TestServiceGrpc.SERVICE)
      .addMethod(
        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
        _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
          serviceAspect.visitUnaryToUnary[hello.world.TestMessage, hello.world.TestMessage](
            _root_.fs2.grpc.server.ServerCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, implicitly[Dom[hello.world.TestMessage]], implicitly[Cod[hello.world.TestMessage]]),
            r,
            (r, m) => serviceImpl.noStreaming(r, m)
          )
        }
      )
      .addMethod(
        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
        _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
          serviceAspect.visitStreamingToUnary[hello.world.TestMessage, hello.world.TestMessage](
            _root_.fs2.grpc.server.ServerCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, implicitly[Dom[hello.world.TestMessage]], implicitly[Cod[hello.world.TestMessage]]),
            r,
            (r, m) => serviceImpl.clientStreaming(r, m)
          )
        }
      )
      .addMethod(
        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
        _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
          serviceAspect.visitUnaryToStreaming[hello.world.TestMessage, hello.world.TestMessage](
            _root_.fs2.grpc.server.ServerCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, implicitly[Dom[hello.world.TestMessage]], implicitly[Cod[hello.world.TestMessage]]),
            r,
            (r, m) => serviceImpl.serverStreaming(r, m)
          )
        }
      )
      .addMethod(
        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
        _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
          serviceAspect.visitStreamingToStreaming[hello.world.TestMessage, hello.world.TestMessage](
            _root_.fs2.grpc.server.ServerCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, implicitly[Dom[hello.world.TestMessage]], implicitly[Cod[hello.world.TestMessage]]),
            r,
            (r, m) => serviceImpl.bothStreaming(r, m)
          )
        }
      )
      .build()
  }
  
  protected def serviceBindingTrivial[F[_]: _root_.cats.effect.Async, A](
    dispatcher: _root_.cats.effect.std.Dispatcher[F],
    serviceImpl: TestServiceFs2Grpc[F, A],
    serviceAspect: _root_.fs2.grpc.server.ServiceAspect[F, _root_.fs2.grpc.shared.Trivial, _root_.fs2.grpc.shared.Trivial, A],
    serverOptions: _root_.fs2.grpc.server.ServerOptions
  ) = 
    serviceBindingFull[F, _root_.fs2.grpc.shared.Trivial, _root_.fs2.grpc.shared.Trivial, A](
      dispatcher,
      serviceImpl,
      serviceAspect,
      serverOptions
    )

}
```
</details>