### PR TITLE
Use scala3 compatible wildcard import

### DIFF
--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2CodeGenerator.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2CodeGenerator.scala
@@ -39,9 +39,9 @@ object Fs2CodeGenerator extends CodeGenApp {
       di: DescriptorImplicits
   ): Seq[PluginProtos.CodeGeneratorResponse.File] = {
     file.getServices.asScala.map { service =>
-      val p = new Fs2GrpcServicePrinter(service, fs2params.serviceSuffix, di)
-
       import di.{ExtendedServiceDescriptor, ExtendedFileDescriptor}
+
+      val p = new Fs2GrpcServicePrinter(service, fs2params.serviceSuffix, di)
       val code = p.printService(FunctionalPrinter()).result()
       val b = PluginProtos.CodeGeneratorResponse.File.newBuilder()
       b.setName(file.scalaDirectory + "/" + service.name + s"${fs2params.serviceSuffix}.scala")

--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2GrpcServicePrinter.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2GrpcServicePrinter.scala
@@ -138,7 +138,7 @@ class Fs2GrpcServicePrinter(service: ServiceDescriptor, serviceSuffix: String, d
 
   def printService(printer: FunctionalPrinter): FunctionalPrinter = {
     printer
-      .add(s"package $servicePkgName", "", "import _root_.cats.syntax.all._", "")
+      .add(s"package $servicePkgName", "", s"import _root_.cats.syntax.all.${service.getFile.V.WildcardImport}", "")
       .call(serviceTrait)
       .newline
       .call(serviceObject)


### PR DESCRIPTION
While working with scala3 and `-source:future` compiler flag, I've got a lot of errors saying that 
```
_root_.cats.syntax.all._
```
is forbidden in scala3.

This change is an attempt to reuse `scala3_sources: true` [setting from scalapb](https://scalapb.github.io/docs/customizations#file-level-options) to obtain which wildcard import should be generated there.