### PR TITLE
Add trailers metadata support in unary response methods

### DIFF
--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2AbstractServicePrinter.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2AbstractServicePrinter.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.codegen
+
+import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
+import fs2.grpc.codegen.Fs2AbstractServicePrinter.constants.{
+  Async,
+  Channel,
+  ClientOptions,
+  Companion,
+  Ctx,
+  Dispatcher,
+  Fs2ClientCall,
+  Fs2ServerCallHandler,
+  Metadata,
+  ServerOptions,
+  ServerServiceDefinition,
+  Stream
+}
+import scalapb.compiler.{DescriptorImplicits, FunctionalPrinter}
+import scalapb.compiler.FunctionalPrinter.PrinterEndo
+
+abstract class Fs2AbstractServicePrinter extends Fs2ServicePrinter {
+
+  val service: ServiceDescriptor
+  val serviceSuffix: String
+  val di: DescriptorImplicits
+
+  import di._
+
+  private[this] val serviceName: String = service.name
+  private[this] val serviceNameFs2: String = s"$serviceName${serviceSuffix}"
+  private[this] val servicePkgName: String = service.getFile.scalaPackage.fullName
+
+  protected def serviceMethodSignature(method: MethodDescriptor): String
+
+  protected[this] def handleMethod(method: MethodDescriptor): String
+
+  private[this] def createClientCall(method: MethodDescriptor) = {
+    val basicClientCall =
+      s"$Fs2ClientCall[F](channel, ${method.grpcDescriptor.fullName}, dispatcher, clientOptions)"
+    if (method.isServerStreaming)
+      s"$Stream.eval($basicClientCall)"
+    else
+      basicClientCall
+  }
+
+  private[this] def serviceMethodImplementation(method: MethodDescriptor): PrinterEndo = { p =>
+    val mkMetadata = if (method.isServerStreaming) s"$Stream.eval(mkMetadata(ctx))" else "mkMetadata(ctx)"
+
+    p.add(serviceMethodSignature(method) + " = {")
+      .indent
+      .add(s"$mkMetadata.flatMap { m =>")
+      .indent
+      .add(s"${createClientCall(method)}.flatMap(_.${handleMethod(method)}(request, m))")
+      .outdent
+      .add("}")
+      .outdent
+      .add("}")
+  }
+
+  private[this] def serviceBindingImplementation(method: MethodDescriptor): PrinterEndo = { p =>
+    val inType = method.inputType.scalaType
+    val outType = method.outputType.scalaType
+    val descriptor = method.grpcDescriptor.fullName
+    val handler = s"$Fs2ServerCallHandler[F](dispatcher, serverOptions).${handleMethod(method)}[$inType, $outType]"
+
+    val serviceCall = s"serviceImpl.${method.name}"
+    val eval = if (method.isServerStreaming) s"$Stream.eval(mkCtx(m))" else "mkCtx(m)"
+
+    p.add(s".addMethod($descriptor, $handler((r, m) => $eval.flatMap($serviceCall(r, _))))")
+  }
+
+  private[this] def serviceMethods: PrinterEndo = _.seq(service.methods.map(serviceMethodSignature))
+
+  private[this] def serviceMethodImplementations: PrinterEndo =
+    _.call(service.methods.map(serviceMethodImplementation): _*)
+
+  private[this] def serviceBindingImplementations: PrinterEndo =
+    _.indent
+      .add(s".builder(${service.grpcDescriptor.fullName})")
+      .call(service.methods.map(serviceBindingImplementation): _*)
+      .add(".build()")
+      .outdent
+
+  private[this] def serviceTrait: PrinterEndo =
+    _.add(s"trait $serviceNameFs2[F[_], $Ctx] {").indent.call(serviceMethods).outdent.add("}")
+
+  private[this] def serviceObject: PrinterEndo =
+    _.add(s"object $serviceNameFs2 extends $Companion[$serviceNameFs2] {").indent.newline
+      .call(serviceClient)
+      .newline
+      .call(serviceBinding)
+      .outdent
+      .newline
+      .add("}")
+
+  private[this] def serviceClient: PrinterEndo = {
+    _.add(
+      s"def mkClient[F[_]: $Async, $Ctx](dispatcher: $Dispatcher[F], channel: $Channel, mkMetadata: $Ctx => F[$Metadata], clientOptions: $ClientOptions): $serviceNameFs2[F, $Ctx] = new $serviceNameFs2[F, $Ctx] {"
+    ).indent
+      .call(serviceMethodImplementations)
+      .outdent
+      .add("}")
+  }
+
+  private[this] def serviceBinding: PrinterEndo = {
+    _.add(
+      s"protected def serviceBinding[F[_]: $Async, $Ctx](dispatcher: $Dispatcher[F], serviceImpl: $serviceNameFs2[F, $Ctx], mkCtx: $Metadata => F[$Ctx], serverOptions: $ServerOptions): $ServerServiceDefinition = {"
+    ).indent
+      .add(s"$ServerServiceDefinition")
+      .call(serviceBindingImplementations)
+      .outdent
+      .add("}")
+  }
+
+  // /
+
+  def printService(printer: FunctionalPrinter): FunctionalPrinter = {
+    printer
+      .add(s"package $servicePkgName", "", "import _root_.cats.syntax.all._", "")
+      .call(serviceTrait)
+      .newline
+      .call(serviceObject)
+  }
+}
+
+object Fs2AbstractServicePrinter {
+  private[codegen] object constants {
+
+    private val effPkg = "_root_.cats.effect"
+    private val fs2Pkg = "_root_.fs2"
+    private val fs2grpcPkg = "_root_.fs2.grpc"
+    private val grpcPkg = "_root_.io.grpc"
+
+    // /
+
+    val Ctx = "A"
+
+    val Async = s"$effPkg.Async"
+    val Resource = s"$effPkg.Resource"
+    val Dispatcher = s"$effPkg.std.Dispatcher"
+    val Stream = s"$fs2Pkg.Stream"
+
+    val Fs2ServerCallHandler = s"$fs2grpcPkg.server.Fs2ServerCallHandler"
+    val Fs2ClientCall = s"$fs2grpcPkg.client.Fs2ClientCall"
+    val ClientOptions = s"$fs2grpcPkg.client.ClientOptions"
+    val ServerOptions = s"$fs2grpcPkg.server.ServerOptions"
+    val Companion = s"$fs2grpcPkg.GeneratedCompanion"
+
+    val ServerServiceDefinition = s"$grpcPkg.ServerServiceDefinition"
+    val Channel = s"$grpcPkg.Channel"
+    val Metadata = s"$grpcPkg.Metadata"
+
+  }
+
+}

--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2ServicePrinter.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2ServicePrinter.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.codegen
+
+import scalapb.compiler.FunctionalPrinter
+
+trait Fs2ServicePrinter {
+  def printService(printer: FunctionalPrinter): FunctionalPrinter
+}

--- a/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
@@ -1,0 +1,47 @@
+package hello.world
+
+import _root_.cats.syntax.all._
+
+trait TestServiceFs2GrpcTrailers[F[_], A] {
+  def noStreaming(request: hello.world.TestMessage, ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+}
+
+object TestServiceFs2GrpcTrailers extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcTrailers] {
+  
+  def mkClient[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], channel: _root_.io.grpc.Channel, mkMetadata: A => F[_root_.io.grpc.Metadata], clientOptions: _root_.fs2.grpc.client.ClientOptions): TestServiceFs2GrpcTrailers[F, A] = new TestServiceFs2GrpcTrailers[F, A] {
+    def noStreaming(request: hello.world.TestMessage, ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] = {
+      mkMetadata(ctx).flatMap { m =>
+        _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(request, m))
+      }
+    }
+    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] = {
+      mkMetadata(ctx).flatMap { m =>
+        _root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(request, m))
+      }
+    }
+    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] = {
+      _root_.fs2.Stream.eval(mkMetadata(ctx)).flatMap { m =>
+        _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(request, m))
+      }
+    }
+    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] = {
+      _root_.fs2.Stream.eval(mkMetadata(ctx)).flatMap { m =>
+        _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[F](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(request, m))
+      }
+    }
+  }
+  
+  protected def serviceBinding[F[_]: _root_.cats.effect.Async, A](dispatcher: _root_.cats.effect.std.Dispatcher[F], serviceImpl: TestServiceFs2GrpcTrailers[F, A], mkCtx: _root_.io.grpc.Metadata => F[A], serverOptions: _root_.fs2.grpc.server.ServerOptions): _root_.io.grpc.ServerServiceDefinition = {
+    _root_.io.grpc.ServerServiceDefinition
+      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .addMethod(hello.world.TestServiceGrpc.METHOD_NO_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.noStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]((r, m) => mkCtx(m).flatMap(serviceImpl.clientStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.serverStreaming(r, _))))
+      .addMethod(hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, _root_.fs2.grpc.server.Fs2ServerCallHandler[F](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]((r, m) => _root_.fs2.Stream.eval(mkCtx(m)).flatMap(serviceImpl.bothStreaming(r, _))))
+      .build()
+  }
+
+}

--- a/e2e/src/test/scala/fs2/grpc/e2e/CodegenSpec.scala
+++ b/e2e/src/test/scala/fs2/grpc/e2e/CodegenSpec.scala
@@ -42,8 +42,21 @@ class Fs2CodeGeneratorSpec extends munit.FunSuite {
 
   }
 
+  test("code generator outputs correct service file for trailers") {
+
+    val testFileName = "TestServiceFs2GrpcTrailers.scala"
+    val reference = Source.fromResource(s"${testFileName}.txt").getLines().mkString("\n")
+    val generated = Source.fromFile(new File(sourcesGenerated, testFileName)).getLines().mkString("\n")
+
+    assertEquals(generated, reference)
+
+  }
+
   test("implicit of companion resolves") {
     implicitly[GeneratedCompanion[TestServiceFs2Grpc]]
   }
 
+  test("implicit of companion resolves trailers") {
+    implicitly[GeneratedCompanion[TestServiceFs2GrpcTrailers]]
+  }
 }

--- a/runtime/src/main/scala/fs2/grpc/client/Fs2ClientCall.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/Fs2ClientCall.scala
@@ -61,11 +61,19 @@ class Fs2ClientCall[F[_], Request, Response] private[client] (
   //
 
   def unaryToUnaryCall(message: Request, headers: Metadata): F[Response] =
+    Fs2UnaryCallHandler.unary(call, options, message, headers).map(_._1)
+
+  def unaryToUnaryCallTrailers(message: Request, headers: Metadata): F[(Response, Metadata)] =
     Fs2UnaryCallHandler.unary(call, options, message, headers)
+
+  def streamingToUnaryCallTrailers(messages: Stream[F, Request], headers: Metadata): F[(Response, Metadata)] =
+    StreamOutput.client(call).flatMap { output =>
+      Fs2UnaryCallHandler.stream(call, options, dispatcher, messages, output, headers)
+    }
 
   def streamingToUnaryCall(messages: Stream[F, Request], headers: Metadata): F[Response] =
     StreamOutput.client(call).flatMap { output =>
-      Fs2UnaryCallHandler.stream(call, options, dispatcher, messages, output, headers)
+      Fs2UnaryCallHandler.stream(call, options, dispatcher, messages, output, headers).map(_._1)
     }
 
   def unaryToStreamingCall(message: Request, md: Metadata): Stream[F, Response] =

--- a/runtime/src/main/scala/fs2/grpc/client/internal/Fs2UnaryCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/internal/Fs2UnaryCallHandler.scala
@@ -38,28 +38,29 @@ private[client] object Fs2UnaryCallHandler {
 
   object ReceiveState {
     def init[F[_]: Sync, R](
-        callback: Either[Throwable, R] => Unit,
+        callback: Either[Throwable, (R, Metadata)] => Unit,
         pf: PartialFunction[StatusRuntimeException, Exception]
     ): F[Ref[SyncIO, ReceiveState[R]]] =
       Ref.in(new PendingMessage[R]({
-        case r: Right[Throwable, R] => callback(r)
+        case r: Right[Throwable, (R, Metadata)] => callback(r)
         case Left(e: StatusRuntimeException) => callback(Left(pf.lift(e).getOrElse(e)))
-        case l: Left[Throwable, R] => callback(l)
+        case l: Left[Throwable, (R, Metadata)] => callback(l)
       }))
   }
 
-  class PendingMessage[R](callback: Either[Throwable, R] => Unit) extends ReceiveState[R] {
+  class PendingMessage[R](callback: Either[Throwable, (R, Metadata)] => Unit) extends ReceiveState[R] {
     def receive(message: R): PendingHalfClose[R] = new PendingHalfClose(callback, message)
 
     def sendError(error: Throwable): SyncIO[ReceiveState[R]] =
       SyncIO(callback(Left(error))).as(new Done[R])
   }
 
-  class PendingHalfClose[R](callback: Either[Throwable, R] => Unit, message: R) extends ReceiveState[R] {
+  class PendingHalfClose[R](callback: Either[Throwable, (R, Metadata)] => Unit, message: R) extends ReceiveState[R] {
     def sendError(error: Throwable): SyncIO[ReceiveState[R]] =
       SyncIO(callback(Left(error))).as(new Done[R])
+    def done: SyncIO[ReceiveState[R]] = SyncIO(callback(Right((message, new Metadata())))).as(new Done[R])
 
-    def done: SyncIO[ReceiveState[R]] = SyncIO(callback(Right(message))).as(new Done[R])
+    def done(trailers: Metadata): SyncIO[ReceiveState[R]] = SyncIO(callback(Right((message, trailers)))).as(new Done[R])
   }
 
   class Done[R] extends ReceiveState[R]
@@ -69,6 +70,7 @@ private[client] object Fs2UnaryCallHandler {
       signalReadiness: SyncIO[Unit]
   ): ClientCall.Listener[Response] =
     new ClientCall.Listener[Response] {
+
       override def onMessage(message: Response): Unit =
         state.get
           .flatMap {
@@ -90,7 +92,7 @@ private[client] object Fs2UnaryCallHandler {
         if (status.isOk) {
           state.get.flatMap {
             case expected: PendingHalfClose[Response] =>
-              expected.done.flatMap(state.set)
+              expected.done(trailers).flatMap(state.set)
             case current: PendingMessage[Response] =>
               current
                 .sendError(
@@ -120,7 +122,7 @@ private[client] object Fs2UnaryCallHandler {
       options: ClientOptions,
       message: Request,
       headers: Metadata
-  )(implicit F: Async[F]): F[Response] = F.async[Response] { cb =>
+  )(implicit F: Async[F]): F[(Response, Metadata)] = F.async[(Response, Metadata)] { cb =>
     ReceiveState.init(cb, options.errorAdapter).map { state =>
       call.start(mkListener[Response](state, SyncIO.unit), headers)
       // Initially ask for two responses from flow-control so that if a misbehaving server
@@ -139,8 +141,8 @@ private[client] object Fs2UnaryCallHandler {
       messages: Stream[F, Request],
       output: StreamOutput[F, Request],
       headers: Metadata
-  )(implicit F: Async[F]): F[Response] = F.async[Response] { cb =>
-    ReceiveState.init(cb, options.errorAdapter).flatMap { state =>
+  )(implicit F: Async[F]): F[(Response, Metadata)] = F.async[(Response, Metadata)] { cb =>
+    ReceiveState.init[F, Response](cb, options.errorAdapter).flatMap { state =>
       call.start(mkListener[Response](state, output.onReadySync(dispatcher)), headers)
       // Initially ask for two responses from flow-control so that if a misbehaving server
       // sends more than one responses, we can catch it and fail it in the listener.

--- a/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/internal/Fs2UnaryServerCallHandler.scala
@@ -90,7 +90,7 @@ private[server] object Fs2UnaryServerCallHandler {
     }
 
   def unary[F[_]: Sync, Request, Response](
-      impl: (Request, Metadata) => F[Response],
+      impl: (Request, Metadata) => F[(Response, Metadata)],
       options: ServerOptions,
       dispatcher: Dispatcher[F]
   ): ServerCallHandler[Request, Response] =

--- a/runtime/src/test/scala/fs2/grpc/server/ServerSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/ServerSuite.scala
@@ -43,7 +43,11 @@ class ServerSuite extends Fs2GrpcSuite {
       options: ServerOptions = ServerOptions.default
   ): (TestContext, Dispatcher[IO]) => Unit = { (tc, d) =>
     val dummy = new DummyServerCall
-    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length), options, d)
+    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int](
+      (req, _) => IO(req.length).map(i => (i, new Metadata())),
+      options,
+      d
+    )
     val listener = handler.startCall(dummy, new Metadata())
 
     listener.onMessage("123")
@@ -58,7 +62,11 @@ class ServerSuite extends Fs2GrpcSuite {
 
   runTest("cancellation for unaryToUnary") { (tc, d) =>
     val dummy = new DummyServerCall
-    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length), ServerOptions.default, d)
+    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int](
+      (req, _) => IO(req.length).map((_, new Metadata())),
+      ServerOptions.default,
+      d
+    )
     val listener = handler.startCall(dummy, new Metadata())
 
     listener.onCancel()
@@ -71,7 +79,7 @@ class ServerSuite extends Fs2GrpcSuite {
   runTest("cancellation on the fly for unaryToUnary") { (tc, d) =>
     val dummy = new DummyServerCall
     val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int](
-      (req, _) => IO(req.length).delayBy(10.seconds),
+      (req, _) => IO(req.length).delayBy(10.seconds).map((_, new Metadata())),
       ServerOptions.default,
       d
     )
@@ -94,7 +102,8 @@ class ServerSuite extends Fs2GrpcSuite {
       options: ServerOptions = ServerOptions.default
   ): (TestContext, Dispatcher[IO]) => Unit = { (tc, d) =>
     val dummy = new DummyServerCall
-    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length), options, d)
+    val handler =
+      Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length).map((_, new Metadata())), options, d)
     val listener = handler.startCall(dummy, new Metadata())
 
     listener.onMessage("123")
@@ -112,7 +121,8 @@ class ServerSuite extends Fs2GrpcSuite {
       options: ServerOptions = ServerOptions.default
   ): (TestContext, Dispatcher[IO]) => Unit = { (tc, d) =>
     val dummy = new DummyServerCall
-    val handler = Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length), options, d)
+    val handler =
+      Fs2UnaryServerCallHandler.unary[IO, String, Int]((req, _) => IO(req.length).map((_, new Metadata())), options, d)
     val listener = handler.startCall(dummy, new Metadata())
 
     listener.onHalfClose()


### PR DESCRIPTION
## Summary

This merge request introduces the capability for servers to send custom metadata (trailers) in responses for unaryToUnary and clientStreaming methods using the fs2.grpc library. Prior to this change, metadata was automatically filled with empty values, with no option for the server to specify or send custom metadata. This enhancement opens up the flexibility for server implementations to include additional information in their responses, providing a richer communication protocol between clients and servers.

## Changes

In this Merge Request, the generation of additional traits and objects with the "Trailers" suffix is added, supporting GRPC trailers metadata. In the signature of the newly generated traits, two methods are modified: noStreaming and clientStreaming. This means that, in these two types of GRPC handlers, the server will be able to specify which metadata it wishes to return, and the client will be able to retrieve this metadata

