### PR TITLE
codegen: remove constants in Fs2GrpcServicePrinter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,8 @@ inThisBuild(
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.client.StreamIngest.create"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.server.Fs2StreamServerCallListener*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.grpc.client.Fs2StreamClientCallListener*"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.grpc.codegen.Fs2GrpcServicePrinter$constants$"),
+      ProblemFilters.exclude[MissingFieldProblem]("fs2.grpc.codegen.Fs2GrpcServicePrinter.constants"),
       // deleted private classes
       ProblemFilters.exclude[MissingClassProblem]("fs2.grpc.client.Fs2UnaryClientCallListener*"),
       ProblemFilters.exclude[MissingClassProblem]("fs2.grpc.server.Fs2UnaryServerCallListener*")

--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2GrpcServicePrinter.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2GrpcServicePrinter.scala
@@ -54,34 +54,4 @@ class Fs2GrpcServicePrinter(val service: ServiceDescriptor, val serviceSuffix: S
 
 }
 
-object Fs2GrpcServicePrinter {
-
-  private[codegen] object constants {
-
-    private val effPkg = "_root_.cats.effect"
-    private val fs2Pkg = "_root_.fs2"
-    private val fs2grpcPkg = "_root_.fs2.grpc"
-    private val grpcPkg = "_root_.io.grpc"
-
-    // /
-
-    val Ctx = "A"
-
-    val Async = s"$effPkg.Async"
-    val Resource = s"$effPkg.Resource"
-    val Dispatcher = s"$effPkg.std.Dispatcher"
-    val Stream = s"$fs2Pkg.Stream"
-
-    val Fs2ServerCallHandler = s"$fs2grpcPkg.server.Fs2ServerCallHandler"
-    val Fs2ClientCall = s"$fs2grpcPkg.client.Fs2ClientCall"
-    val ClientOptions = s"$fs2grpcPkg.client.ClientOptions"
-    val ServerOptions = s"$fs2grpcPkg.server.ServerOptions"
-    val Companion = s"$fs2grpcPkg.GeneratedCompanion"
-
-    val ServerServiceDefinition = s"$grpcPkg.ServerServiceDefinition"
-    val Channel = s"$grpcPkg.Channel"
-    val Metadata = s"$grpcPkg.Metadata"
-
-  }
-
-}
+object Fs2GrpcServicePrinter {}


### PR DESCRIPTION
Remove `constants` from `Fs2GrpcServicePrinter` as it is now in `Fs2AbstractServicePrinter`.