### PR TITLE
Add Scaladoc for Fs2Grpc services and methods (#776)

### DIFF
--- a/e2e/src/main/protobuf/test_service.proto
+++ b/e2e/src/main/protobuf/test_service.proto
@@ -4,9 +4,15 @@ import "test.proto";
 
 package hello.world;
 
-service TestService {  
+// TestService: Example gRPC service used in e2e tests
+// It demonstrates all four RPC shapes.
+service TestService {
+  // Unary RPC: no streaming in either direction
   rpc noStreaming (TestMessage) returns (TestMessage);
+  // Client streaming RPC: client streams, server returns a single response
   rpc clientStreaming (stream TestMessage) returns (TestMessage);
+  // Server streaming RPC: client sends one request, server streams responses
   rpc serverStreaming (TestMessage) returns (stream TestMessage);
+  // Bidirectional streaming RPC: both client and server stream
   rpc bothStreaming (stream TestMessage) returns (stream TestMessage);
 }

--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -2,10 +2,21 @@ package hello.world
 
 import _root_.cats.syntax.all._
 
+/** TestService: Example gRPC service used in e2e tests
+  * It demonstrates all four RPC shapes.
+  */
 trait TestServiceFs2Grpc[F[_], A] {
+  /** Unary RPC: no streaming in either direction
+    */
   def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage]
+  /** Client streaming RPC: client streams, server returns a single response
+    */
   def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage]
+  /** Server streaming RPC: client sends one request, server streams responses
+    */
   def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  /** Bidirectional streaming RPC: both client and server stream
+    */
   def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
 }
 

--- a/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
@@ -2,10 +2,21 @@ package hello.world
 
 import _root_.cats.syntax.all._
 
+/** TestService: Example gRPC service used in e2e tests
+  * It demonstrates all four RPC shapes.
+  */
 trait TestServiceFs2GrpcTrailers[F[_], A] {
+  /** Unary RPC: no streaming in either direction
+    */
   def noStreaming(request: hello.world.TestMessage, ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  /** Client streaming RPC: client streams, server returns a single response
+    */
   def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  /** Server streaming RPC: client sends one request, server streams responses
+    */
   def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  /** Bidirectional streaming RPC: both client and server stream
+    */
   def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
 }
 


### PR DESCRIPTION
Fix #776 

First attempt to add Scaladoc to gRPC services and methods. All tests are passing, and the e2e has been updated to reflect the new documentation. I didn't write complex test cases as the logic is already tested in scalapb. 

The main logic is taken from `scalapb.compiler.GrpcServicePrinter`. In particular, `generateScalaDoc` is using utility code from the scalapb compiler project.