### PR TITLE
Allow generating context as an implicit parameter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -161,14 +161,27 @@ lazy val e2e = (projectMatrix in file("e2e"))
         val output = (Compile / sourceManaged).value / "fs2-grpc" / "disable-trailers"
       }
 
+      val renderContextAsImplicit = new {
+        val args = Seq(
+          "fs2_grpc:service_suffix=Fs2GrpcRenderContextAsImplicit",
+          "fs2_grpc:render_context_as_implicit"
+        ) ++ (if (tlIsScala3.value) Seq("scala3_sources") else Nil)
+
+        val output = (Compile / sourceManaged).value / "fs2-grpc" / "render-context-as-implicit"
+      }
+
       Seq(
         scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
         genModule(codegenFullName + "$") -> (Compile / sourceManaged).value / "fs2-grpc",
-        (genModule(codegenFullName + "$"), disableTrailers.args) -> disableTrailers.output
+        (genModule(codegenFullName + "$"), disableTrailers.args) -> disableTrailers.output,
+        (genModule(codegenFullName + "$"), renderContextAsImplicit.args) -> renderContextAsImplicit.output
       )
     },
     buildInfoPackage := "fs2.grpc.e2e.buildinfo",
-    buildInfoKeys := Seq[BuildInfoKey]("sourceManaged" -> (Compile / sourceManaged).value / "fs2-grpc"),
+    buildInfoKeys := Seq[BuildInfoKey](
+      "sourceManaged" -> (Compile / sourceManaged).value / "fs2-grpc",
+      "scalaVersion" -> scalaVersion.value
+    ),
     githubWorkflowArtifactUpload := false,
     scalacOptions := {
       if (tlIsScala3.value) {

--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2GrpcExhaustiveTrailersServicePrinter.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2GrpcExhaustiveTrailersServicePrinter.scala
@@ -27,6 +27,8 @@ import scalapb.compiler.{DescriptorImplicits, StreamType}
 class Fs2GrpcExhaustiveTrailersServicePrinter(
     val service: ServiceDescriptor,
     val serviceSuffix: String,
+    override val renderContextAsImplicit: Boolean,
+    override val scala3Sources: Boolean,
     val di: DescriptorImplicits
 ) extends Fs2AbstractServicePrinter {
   import fs2.grpc.codegen.Fs2AbstractServicePrinter.constants._
@@ -36,13 +38,13 @@ class Fs2GrpcExhaustiveTrailersServicePrinter(
 
     val scalaInType = method.inputType.scalaType
     val scalaOutType = method.outputType.scalaType
-    val ctx = s"ctx: $Ctx"
+    val ctx = renderCtxParameter()
 
     s"def ${method.name}" + (method.streamType match {
-      case StreamType.Unary => s"(request: $scalaInType, $ctx): F[($scalaOutType, $Metadata)]"
-      case StreamType.ClientStreaming => s"(request: $Stream[F, $scalaInType], $ctx): F[($scalaOutType, $Metadata)]"
-      case StreamType.ServerStreaming => s"(request: $scalaInType, $ctx): $Stream[F, $scalaOutType]"
-      case StreamType.Bidirectional => s"(request: $Stream[F, $scalaInType], $ctx): $Stream[F, $scalaOutType]"
+      case StreamType.Unary => s"(request: $scalaInType$ctx): F[($scalaOutType, $Metadata)]"
+      case StreamType.ClientStreaming => s"(request: $Stream[F, $scalaInType]$ctx): F[($scalaOutType, $Metadata)]"
+      case StreamType.ServerStreaming => s"(request: $scalaInType$ctx): $Stream[F, $scalaOutType]"
+      case StreamType.Bidirectional => s"(request: $Stream[F, $scalaInType]$ctx): $Stream[F, $scalaOutType]"
     })
   }
 

--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2GrpcServicePrinter.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2GrpcServicePrinter.scala
@@ -24,8 +24,13 @@ package fs2.grpc.codegen
 import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
 import scalapb.compiler.{DescriptorImplicits, StreamType}
 
-class Fs2GrpcServicePrinter(val service: ServiceDescriptor, val serviceSuffix: String, val di: DescriptorImplicits)
-    extends Fs2AbstractServicePrinter {
+class Fs2GrpcServicePrinter(
+    val service: ServiceDescriptor,
+    val serviceSuffix: String,
+    override val renderContextAsImplicit: Boolean,
+    override val scala3Sources: Boolean,
+    val di: DescriptorImplicits
+) extends Fs2AbstractServicePrinter {
   import fs2.grpc.codegen.Fs2AbstractServicePrinter.constants._
   import di._
 
@@ -33,13 +38,13 @@ class Fs2GrpcServicePrinter(val service: ServiceDescriptor, val serviceSuffix: S
 
     val scalaInType = method.inputType.scalaType
     val scalaOutType = method.outputType.scalaType
-    val ctx = s"ctx: $Ctx"
+    val ctx = renderCtxParameter()
 
     s"def ${method.name}" + (method.streamType match {
-      case StreamType.Unary => s"(request: $scalaInType, $ctx): F[$scalaOutType]"
-      case StreamType.ClientStreaming => s"(request: $Stream[F, $scalaInType], $ctx): F[$scalaOutType]"
-      case StreamType.ServerStreaming => s"(request: $scalaInType, $ctx): $Stream[F, $scalaOutType]"
-      case StreamType.Bidirectional => s"(request: $Stream[F, $scalaInType], $ctx): $Stream[F, $scalaOutType]"
+      case StreamType.Unary => s"(request: $scalaInType$ctx): F[$scalaOutType]"
+      case StreamType.ClientStreaming => s"(request: $Stream[F, $scalaInType]$ctx): F[$scalaOutType]"
+      case StreamType.ServerStreaming => s"(request: $scalaInType$ctx): $Stream[F, $scalaOutType]"
+      case StreamType.Bidirectional => s"(request: $Stream[F, $scalaInType]$ctx): $Stream[F, $scalaOutType]"
     })
   }
 

--- a/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicit.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicit.scala.txt
@@ -1,0 +1,110 @@
+package hello.world
+
+import _root_.cats.syntax.all._
+
+/** TestService: Example gRPC service used in e2e tests
+  * It demonstrates all four RPC shapes.
+  */
+trait TestServiceFs2GrpcRenderContextAsImplicit[F[_], A] {
+  /** Unary RPC: no streaming in either direction
+    */
+  def noStreaming(request: hello.world.TestMessage)(implicit ctx: A): F[hello.world.TestMessage]
+  /** Client streaming RPC: client streams, server returns a single response
+    */
+  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): F[hello.world.TestMessage]
+  /** Server streaming RPC: client sends one request, server streams responses
+    */
+  def serverStreaming(request: hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  /** Bidirectional streaming RPC: both client and server stream
+    */
+  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+}
+
+object TestServiceFs2GrpcRenderContextAsImplicit extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicit] {
+  
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  
+  def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    channel: _root_.io.grpc.Channel,
+    clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
+    clientOptions: _root_.fs2.grpc.client.ClientOptions
+  ): TestServiceFs2GrpcRenderContextAsImplicit[F, A] = new TestServiceFs2GrpcRenderContextAsImplicit[F, A] {
+    def noStreaming(request: hello.world.TestMessage)(implicit ctx: A): F[hello.world.TestMessage] =
+      clientAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
+      )
+    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): F[hello.world.TestMessage] =
+      clientAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
+      )
+    def serverStreaming(request: hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+      )
+    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+      )
+  }
+  
+  protected def serviceBindingFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    serviceImpl: TestServiceFs2GrpcRenderContextAsImplicit[F, A],
+    serviceAspect: _root_.fs2.grpc.server.ServiceAspect[F, G, A],
+    serverOptions: _root_.fs2.grpc.server.ServerOptions
+  ) = {
+    _root_.io.grpc.ServerServiceDefinition
+      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+            r,
+            (r, m) => serviceImpl.noStreaming(r)(m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+            r,
+            (r, m) => serviceImpl.clientStreaming(r)(m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+            r,
+            (r, m) => serviceImpl.serverStreaming(r)(m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+            r,
+            (r, m) => serviceImpl.bothStreaming(r)(m)
+          )
+        }
+      )
+      .build()
+  }
+
+}

--- a/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitScala3.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitScala3.scala.txt
@@ -1,0 +1,110 @@
+package hello.world
+
+import _root_.cats.syntax.all.*
+
+/** TestService: Example gRPC service used in e2e tests
+  * It demonstrates all four RPC shapes.
+  */
+trait TestServiceFs2GrpcRenderContextAsImplicit[F[_], A] {
+  /** Unary RPC: no streaming in either direction
+    */
+  def noStreaming(request: hello.world.TestMessage)(using ctx: A): F[hello.world.TestMessage]
+  /** Client streaming RPC: client streams, server returns a single response
+    */
+  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): F[hello.world.TestMessage]
+  /** Server streaming RPC: client sends one request, server streams responses
+    */
+  def serverStreaming(request: hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  /** Bidirectional streaming RPC: both client and server stream
+    */
+  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+}
+
+object TestServiceFs2GrpcRenderContextAsImplicit extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicit] {
+  
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  
+  def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    channel: _root_.io.grpc.Channel,
+    clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
+    clientOptions: _root_.fs2.grpc.client.ClientOptions
+  ): TestServiceFs2GrpcRenderContextAsImplicit[F, A] = new TestServiceFs2GrpcRenderContextAsImplicit[F, A] {
+    def noStreaming(request: hello.world.TestMessage)(using ctx: A): F[hello.world.TestMessage] =
+      clientAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
+      )
+    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): F[hello.world.TestMessage] =
+      clientAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
+      )
+    def serverStreaming(request: hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+      )
+    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+      )
+  }
+  
+  protected def serviceBindingFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    serviceImpl: TestServiceFs2GrpcRenderContextAsImplicit[F, A],
+    serviceAspect: _root_.fs2.grpc.server.ServiceAspect[F, G, A],
+    serverOptions: _root_.fs2.grpc.server.ServerOptions
+  ) = {
+    _root_.io.grpc.ServerServiceDefinition
+      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+            r,
+            (r, m) => serviceImpl.noStreaming(r)(using m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+            r,
+            (r, m) => serviceImpl.clientStreaming(r)(using m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+            r,
+            (r, m) => serviceImpl.serverStreaming(r)(using m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+            r,
+            (r, m) => serviceImpl.bothStreaming(r)(using m)
+          )
+        }
+      )
+      .build()
+  }
+
+}

--- a/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitTrailers.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitTrailers.scala.txt
@@ -1,0 +1,110 @@
+package hello.world
+
+import _root_.cats.syntax.all._
+
+/** TestService: Example gRPC service used in e2e tests
+  * It demonstrates all four RPC shapes.
+  */
+trait TestServiceFs2GrpcRenderContextAsImplicitTrailers[F[_], A] {
+  /** Unary RPC: no streaming in either direction
+    */
+  def noStreaming(request: hello.world.TestMessage)(implicit ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  /** Client streaming RPC: client streams, server returns a single response
+    */
+  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  /** Server streaming RPC: client sends one request, server streams responses
+    */
+  def serverStreaming(request: hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  /** Bidirectional streaming RPC: both client and server stream
+    */
+  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+}
+
+object TestServiceFs2GrpcRenderContextAsImplicitTrailers extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicitTrailers] {
+  
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  
+  def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    channel: _root_.io.grpc.Channel,
+    clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
+    clientOptions: _root_.fs2.grpc.client.ClientOptions
+  ): TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A] = new TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A] {
+    def noStreaming(request: hello.world.TestMessage)(implicit ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
+      )
+    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
+      )
+    def serverStreaming(request: hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+      )
+    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+      )
+  }
+  
+  protected def serviceBindingFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    serviceImpl: TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A],
+    serviceAspect: _root_.fs2.grpc.server.ServiceAspect[F, G, A],
+    serverOptions: _root_.fs2.grpc.server.ServerOptions
+  ) = {
+    _root_.io.grpc.ServerServiceDefinition
+      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+            r,
+            (r, m) => serviceImpl.noStreaming(r)(m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+            r,
+            (r, m) => serviceImpl.clientStreaming(r)(m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+            r,
+            (r, m) => serviceImpl.serverStreaming(r)(m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+            r,
+            (r, m) => serviceImpl.bothStreaming(r)(m)
+          )
+        }
+      )
+      .build()
+  }
+
+}

--- a/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitTrailersScala3.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitTrailersScala3.scala.txt
@@ -1,0 +1,110 @@
+package hello.world
+
+import _root_.cats.syntax.all.*
+
+/** TestService: Example gRPC service used in e2e tests
+  * It demonstrates all four RPC shapes.
+  */
+trait TestServiceFs2GrpcRenderContextAsImplicitTrailers[F[_], A] {
+  /** Unary RPC: no streaming in either direction
+    */
+  def noStreaming(request: hello.world.TestMessage)(using ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  /** Client streaming RPC: client streams, server returns a single response
+    */
+  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  /** Server streaming RPC: client sends one request, server streams responses
+    */
+  def serverStreaming(request: hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  /** Bidirectional streaming RPC: both client and server stream
+    */
+  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+}
+
+object TestServiceFs2GrpcRenderContextAsImplicitTrailers extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicitTrailers] {
+  
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  
+  def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    channel: _root_.io.grpc.Channel,
+    clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
+    clientOptions: _root_.fs2.grpc.client.ClientOptions
+  ): TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A] = new TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A] {
+    def noStreaming(request: hello.world.TestMessage)(using ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
+      )
+    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        request,
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
+      )
+    def serverStreaming(request: hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+      )
+    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        request,
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+      )
+  }
+  
+  protected def serviceBindingFull[F[_], G[_]: _root_.cats.effect.Async, A](
+    dispatcher: _root_.cats.effect.std.Dispatcher[G],
+    serviceImpl: TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A],
+    serviceAspect: _root_.fs2.grpc.server.ServiceAspect[F, G, A],
+    serverOptions: _root_.fs2.grpc.server.ServerOptions
+  ) = {
+    _root_.io.grpc.ServerServiceDefinition
+      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+            r,
+            (r, m) => serviceImpl.noStreaming(r)(using m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+            r,
+            (r, m) => serviceImpl.clientStreaming(r)(using m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+            r,
+            (r, m) => serviceImpl.serverStreaming(r)(using m)
+          )
+        }
+      )
+      .addMethod(
+        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+            r,
+            (r, m) => serviceImpl.bothStreaming(r)(using m)
+          )
+        }
+      )
+      .build()
+  }
+
+}

--- a/e2e/src/test/scala/fs2/grpc/e2e/Fs2CodeGeneratorRenderContextAsImplicitSpec.scala
+++ b/e2e/src/test/scala/fs2/grpc/e2e/Fs2CodeGeneratorRenderContextAsImplicitSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.e2e
+
+import java.io.File
+
+import fs2.grpc.GeneratedCompanion
+import fs2.grpc.e2e.buildinfo.BuildInfo.{sourceManaged, scalaVersion}
+import hello.world._
+
+import scala.io.Source
+
+class Fs2CodeGeneratorRenderContextAsImplicitSpec extends munit.FunSuite {
+
+  val sourcesGenerated = new File(sourceManaged.getAbsolutePath, "render-context-as-implicit/hello/world")
+  val suffix = if (scalaVersion.startsWith("3")) "Scala3" else ""
+
+  test("code generator outputs correct service file") {
+    val fileName = "TestServiceFs2GrpcRenderContextAsImplicit"
+    val testFileName = s"$fileName.scala"
+    val referenceName = s"$fileName$suffix.scala"
+    val reference = Source.fromResource(s"$referenceName.txt").getLines().mkString("\n")
+    val generated = Source.fromFile(new File(sourcesGenerated, testFileName)).getLines().mkString("\n")
+
+    assertEquals(generated, reference)
+  }
+
+  test("code generator outputs correct service file for trailers") {
+    val fileName = s"TestServiceFs2GrpcRenderContextAsImplicitTrailers"
+    val testFileName = s"$fileName.scala"
+    val referenceName = s"$fileName$suffix.scala"
+    val reference = Source.fromResource(s"$referenceName.txt").getLines().mkString("\n")
+    val generated = Source.fromFile(new File(sourcesGenerated, testFileName)).getLines().mkString("\n")
+
+    assertEquals(generated, reference)
+  }
+
+  test("implicit of companion resolves") {
+    implicitly[GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicit]]
+  }
+
+  test("implicit of companion resolves trailers") {
+    implicitly[GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicitTrailers]]
+  }
+
+}

--- a/plugin/src/main/scala/fs2/grpc/codegen/Fs2GrpcPlugin.scala
+++ b/plugin/src/main/scala/fs2/grpc/codegen/Fs2GrpcPlugin.scala
@@ -81,6 +81,22 @@ object Fs2GrpcPlugin extends AutoPlugin {
       case object Fs2GrpcDisableTrailers extends CodeGeneratorOption {
         override def toString: String = "fs2_grpc:disable_trailers"
       }
+
+      /** Renders context in the implicit position.
+        *
+        * Scala 2:
+        * {{{
+        *   def noStreaming(request: Req)(implicit ctx: A): F[Resp]
+        * }}}
+        *
+        * Scala 3, when `Scala3Sources` code generator is used:
+        * {{{
+        *   def noStreaming(request: Req)(using ctx: A): F[Resp]
+        * }}}
+        */
+      case object Fs2GrpcRenderContextAsImplicit extends CodeGeneratorOption {
+        override def toString: String = "fs2_grpc:render_context_as_implicit"
+      }
     }
 
     val scalapbCodeGeneratorOptions =

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-render-context-as-implicit/build.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-render-context-as-implicit/build.sbt
@@ -1,0 +1,8 @@
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(Fs2Grpc)
+  .settings(
+    scalaVersion := "3.7.3",
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.Scala3Sources,
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.Fs2GrpcRenderContextAsImplicit
+  )

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-render-context-as-implicit/project/plugins.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-render-context-as-implicit/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.typelevel" % "sbt-fs2-grpc" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-render-context-as-implicit/src/main/protobuf/test_service.proto
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-render-context-as-implicit/src/main/protobuf/test_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package hello.world;
+
+// TestService: Example gRPC service used in e2e tests
+// It demonstrates all four RPC shapes.
+service TestService {
+  // Unary RPC: no streaming in either direction
+  rpc noStreaming (TestMessage) returns (TestMessage);
+  // Client streaming RPC: client streams, server returns a single response
+  rpc clientStreaming (stream TestMessage) returns (TestMessage);
+  // Server streaming RPC: client sends one request, server streams responses
+  rpc serverStreaming (TestMessage) returns (stream TestMessage);
+  // Bidirectional streaming RPC: both client and server stream
+  rpc bothStreaming (stream TestMessage) returns (stream TestMessage);
+}
+
+message TestMessage {}

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-render-context-as-implicit/test
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-render-context-as-implicit/test
@@ -1,0 +1,3 @@
+> compile
+$ exec bash -c 'grep -q "(using ctx: A)" target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceFs2Grpc.scala || exit 1'
+$ exec bash -c 'grep -q "(using ctx: A)" target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceFs2GrpcTrailers.scala || exit 1'


### PR DESCRIPTION
### Motivation

With the recently released https://github.com/typelevel/fs2-grpc/pull/669, there is a new scenario where the context can be extended, and it can be passed implicitly to inner functions.

Let's consider the following example:
```scala
class Ctx(...) 
class TracingMetadata(tracingCtx: Ctx, metadata: io.grpc.Metadata)

class Service extends ServiceFs2GrpcTrailers[IO, TracingMetadata] {

  def endpoint(request: Request, ctx: TracingMetadata): IO[Response] = {
    given Ctx = ctx.tracing
    for {
      _ <- log("handling request")
      r <- logic(request)
    } yield r
  }
  
  def logic(r: Request)(using Ctx): IO[Response] = ???
  def log(str: String)(using Ctx): IO[Unit] = ???
  
}
```

The usage is a little noisy and repetitive. With the new flag, we can put ctx into an implicit position in the generated service:
```scala
given (using m: Meta): Ctx = m.c

class Service extends ServiceFs2GrpcTrailers[IO, TracingMetadata] {

  def endpoint(request: Request)(using ctx: TracingMetadata): IO[Response] = 
    for {
      _ <- log("handling request")
      r <- logic(request)
    } yield r
  
  def logic(r: Request)(using Ctx): IO[Response] = ???
  def log(str: String)(using Ctx): IO[Unit] = ???
  
}
```

