### PR TITLE
Add `Fs2GrpcServiceSuffix` code generator option

### DIFF
--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2CodeGenerator.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2CodeGenerator.scala
@@ -117,6 +117,8 @@ object Fs2CodeGenerator extends CodeGenApp {
       suffix <- unparsed.map(_.split("=", 2).toList).foldLeft[Either[String, Fs2Params]](Right(Fs2Params.default)) {
         case (Right(params), ServiceSuffix :: suffix :: Nil) => Right(params.withServiceSuffix(suffix))
         case (Right(params), DisableTrailers :: Nil) => Right(params.withDisableTrailers(true))
+        case (Right(_), ServiceSuffixPluginKey :: _ :: Nil) =>
+          Left(s"The '$ServiceSuffixPluginKey' is replaced with '$ServiceSuffix'")
         case (Right(_), xs) => Left(s"Unrecognized parameter: $xs")
         case (Left(e), _) => Left(e)
       }
@@ -147,6 +149,7 @@ object Fs2CodeGenerator extends CodeGenApp {
     process(CodeGenRequest(request)).toCodeGeneratorResponse
   }
 
-  private[codegen] val ServiceSuffix: String = "serviceSuffix"
+  private[codegen] val ServiceSuffixPluginKey: String = "serviceSuffix"
+  private[codegen] val ServiceSuffix: String = "fs2_grpc:service_suffix"
   private[codegen] val DisableTrailers: String = "fs2_grpc:disable_trailers"
 }

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-disable-trailers/build.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-disable-trailers/build.sbt
@@ -1,0 +1,8 @@
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(Fs2Grpc)
+  .settings(
+    scalaVersion := "3.7.3",
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.Scala3Sources,
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.Fs2GrpcDisableTrailers
+  )

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-disable-trailers/project/plugins.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-disable-trailers/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.typelevel" % "sbt-fs2-grpc" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-disable-trailers/src/main/protobuf/test_service.proto
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-disable-trailers/src/main/protobuf/test_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package hello.world;
+
+// TestService: Example gRPC service used in e2e tests
+// It demonstrates all four RPC shapes.
+service TestService {
+  // Unary RPC: no streaming in either direction
+  rpc noStreaming (TestMessage) returns (TestMessage);
+  // Client streaming RPC: client streams, server returns a single response
+  rpc clientStreaming (stream TestMessage) returns (TestMessage);
+  // Server streaming RPC: client sends one request, server streams responses
+  rpc serverStreaming (TestMessage) returns (stream TestMessage);
+  // Bidirectional streaming RPC: both client and server stream
+  rpc bothStreaming (stream TestMessage) returns (stream TestMessage);
+}
+
+message TestMessage {}

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-disable-trailers/test
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-disable-trailers/test
@@ -1,0 +1,3 @@
+> compile
+$ exists target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceFs2Grpc.scala
+$ absent target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceFs2GrpcTrailers.scala

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-service-suffix/build.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-service-suffix/build.sbt
@@ -1,0 +1,8 @@
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(Fs2Grpc)
+  .settings(
+    scalaVersion := "3.7.3",
+    fs2GrpcServiceSuffix := "SomeSuffix",
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.Scala3Sources
+  )

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-service-suffix/project/plugins.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-service-suffix/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.typelevel" % "sbt-fs2-grpc" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-service-suffix/src/main/protobuf/test_service.proto
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-service-suffix/src/main/protobuf/test_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package hello.world;
+
+// TestService: Example gRPC service used in e2e tests
+// It demonstrates all four RPC shapes.
+service TestService {
+  // Unary RPC: no streaming in either direction
+  rpc noStreaming (TestMessage) returns (TestMessage);
+  // Client streaming RPC: client streams, server returns a single response
+  rpc clientStreaming (stream TestMessage) returns (TestMessage);
+  // Server streaming RPC: client sends one request, server streams responses
+  rpc serverStreaming (TestMessage) returns (stream TestMessage);
+  // Bidirectional streaming RPC: both client and server stream
+  rpc bothStreaming (stream TestMessage) returns (stream TestMessage);
+}
+
+message TestMessage {}

--- a/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-service-suffix/test
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/code-generator-option-service-suffix/test
@@ -1,0 +1,3 @@
+> compile
+$ exists target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceSomeSuffix.scala
+$ exists target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceSomeSuffixTrailers.scala

--- a/plugin/src/sbt-test/fs2-grpc-sbt/default/build.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/default/build.sbt
@@ -1,0 +1,7 @@
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(Fs2Grpc)
+  .settings(
+    scalaVersion := "3.7.3",
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.Scala3Sources
+  )

--- a/plugin/src/sbt-test/fs2-grpc-sbt/default/project/plugins.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/default/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.typelevel" % "sbt-fs2-grpc" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/fs2-grpc-sbt/default/src/main/protobuf/test_service.proto
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/default/src/main/protobuf/test_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package hello.world;
+
+// TestService: Example gRPC service used in e2e tests
+// It demonstrates all four RPC shapes.
+service TestService {
+  // Unary RPC: no streaming in either direction
+  rpc noStreaming (TestMessage) returns (TestMessage);
+  // Client streaming RPC: client streams, server returns a single response
+  rpc clientStreaming (stream TestMessage) returns (TestMessage);
+  // Server streaming RPC: client sends one request, server streams responses
+  rpc serverStreaming (TestMessage) returns (stream TestMessage);
+  // Bidirectional streaming RPC: both client and server stream
+  rpc bothStreaming (stream TestMessage) returns (stream TestMessage);
+}
+
+message TestMessage {}

--- a/plugin/src/sbt-test/fs2-grpc-sbt/default/test
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/default/test
@@ -1,0 +1,3 @@
+> compile
+$ exists target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceFs2Grpc.scala
+$ exists target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceFs2GrpcTrailers.scala

--- a/plugin/src/sbt-test/fs2-grpc-sbt/service-suffix-plugin-key/build.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/service-suffix-plugin-key/build.sbt
@@ -1,0 +1,8 @@
+lazy val root = project
+  .in(file("."))
+  .enablePlugins(Fs2Grpc)
+  .settings(
+    scalaVersion := "3.7.3",
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.Scala3Sources,
+    scalapbCodeGeneratorOptions += CodeGeneratorOption.Fs2GrpcServiceSuffix("SomeSuffix"),
+  )

--- a/plugin/src/sbt-test/fs2-grpc-sbt/service-suffix-plugin-key/project/plugins.sbt
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/service-suffix-plugin-key/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.typelevel" % "sbt-fs2-grpc" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/fs2-grpc-sbt/service-suffix-plugin-key/src/main/protobuf/test_service.proto
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/service-suffix-plugin-key/src/main/protobuf/test_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package hello.world;
+
+// TestService: Example gRPC service used in e2e tests
+// It demonstrates all four RPC shapes.
+service TestService {
+  // Unary RPC: no streaming in either direction
+  rpc noStreaming (TestMessage) returns (TestMessage);
+  // Client streaming RPC: client streams, server returns a single response
+  rpc clientStreaming (stream TestMessage) returns (TestMessage);
+  // Server streaming RPC: client sends one request, server streams responses
+  rpc serverStreaming (TestMessage) returns (stream TestMessage);
+  // Bidirectional streaming RPC: both client and server stream
+  rpc bothStreaming (stream TestMessage) returns (stream TestMessage);
+}
+
+message TestMessage {}

--- a/plugin/src/sbt-test/fs2-grpc-sbt/service-suffix-plugin-key/test
+++ b/plugin/src/sbt-test/fs2-grpc-sbt/service-suffix-plugin-key/test
@@ -1,0 +1,3 @@
+> compile
+$ exists target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceSomeSuffix.scala
+$ exists target/scala-3.7.3/src_managed/main/fs2-grpc/hello/world/test_service/TestServiceSomeSuffixTrailers.scala


### PR DESCRIPTION
The changes:
- Added `Fs2GrpcServiceSuffix` code generator option
- Configured a few sbt plugin tests
- Deprecated `fs2GrpcServiceSuffix` plugin key