### PR TITLE
Use array-backed buffer for incoming messages in 'StreamIngest'

### DIFF
--- a/runtime/src/test/scala/fs2/grpc/shared/StreamIngestSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/shared/StreamIngestSuite.scala
@@ -30,24 +30,34 @@ class StreamIngestSuite extends CatsEffectSuite with CatsEffectFunFixtures {
 
   test("basic") {
 
-    def run(prefetchN: Int, takeN: Int, expectedReq: Int, expectedCount: Int) = {
+    def run(emitN: Int, prefetchN: Int, takeN: Int, expectedReq: Int, expectedCount: Int) = {
+      def capture(s: Stream[IO, Int]): IO[List[Int]] = s.take(takeN.toLong).compile.toList
+
       for {
         ref <- IO.ref(0)
         ingest <- StreamIngest[IO, Int](req => ref.update(_ + req), prefetchN)
-        _ <- Stream.emits((1 to prefetchN)).evalTap(ingest.onMessage).compile.drain
-        messages <- ingest.messages.take(takeN.toLong).compile.toList
+        emitted = Stream.emits((1 to emitN)).covary[IO]
+        _ <- emitted.evalTap(ingest.onMessage).compile.drain
+        expected <- capture(emitted)
+        messages <- capture(ingest.messages)
         requested <- ref.get
       } yield {
         assertEquals(messages.size, expectedCount)
+        assertEquals(messages, expected)
         assertEquals(requested, expectedReq)
       }
     }
 
-    run(prefetchN = 1, takeN = 1, expectedReq = 1, expectedCount = 1) *>
-      run(prefetchN = 2, takeN = 1, expectedReq = 2, expectedCount = 1) *>
-      run(prefetchN = 2, takeN = 2, expectedReq = 2, expectedCount = 2) *>
-      run(prefetchN = 1024, takeN = 1024, expectedReq = 1024, expectedCount = 1024) *>
-      run(prefetchN = 1024, takeN = 1023, expectedReq = 1024, expectedCount = 1023)
+    run(emitN = 1, prefetchN = 1, takeN = 1, expectedReq = 0, expectedCount = 1) *>
+      run(emitN = 1, prefetchN = 2, takeN = 1, expectedReq = 2, expectedCount = 1) *>
+      run(emitN = 2, prefetchN = 2, takeN = 1, expectedReq = 0, expectedCount = 1) *>
+      run(emitN = 2, prefetchN = 4, takeN = 1, expectedReq = 4, expectedCount = 1) *>
+      run(emitN = 2, prefetchN = 1, takeN = 2, expectedReq = 0, expectedCount = 2) *>
+      run(emitN = 2, prefetchN = 4, takeN = 2, expectedReq = 4, expectedCount = 2) *>
+      run(emitN = 1024, prefetchN = 1024, takeN = 1024, expectedReq = 0, expectedCount = 1024) *>
+      run(emitN = 1024, prefetchN = 2048, takeN = 1024, expectedReq = 2048, expectedCount = 1024) *>
+      run(emitN = 1024, prefetchN = 1024, takeN = 1023, expectedReq = 0, expectedCount = 1023)
+    run(emitN = 1024, prefetchN = 2048, takeN = 1023, expectedReq = 2048, expectedCount = 1023)
 
   }
 


### PR DESCRIPTION
If value of `prefetchN` option set for client- or server-side streaming calls is bigger than some arbitrary threshold, `fs2.Chunk.ArraySlice` will be used for incoming messages with shared array buffer underneath.

Currently threshold is set to `prefetchN == 14` so that minimal size of array is 128 bytes (12 + 4 + 14 * 8) for 'CompressedOops' pointers.

Some benchmarks are needed to check if this optimisation is worthy of involved code complexity.