### PR TITLE
Upgrade ScalaPB to 1.0.0-alpha.3 to support protobuf 28

### DIFF
--- a/codegen/src/main/scala/fs2/grpc/codegen/Fs2AbstractServicePrinter.scala
+++ b/codegen/src/main/scala/fs2/grpc/codegen/Fs2AbstractServicePrinter.scala
@@ -39,7 +39,7 @@ abstract class Fs2AbstractServicePrinter extends Fs2ServicePrinter {
 
   private[this] val serviceName: String = service.name
   private[this] val serviceNameFs2: String = s"$serviceName${serviceSuffix}"
-  private[this] val servicePkgName: String = service.getFile.scalaPackage.fullName
+  private[this] val servicePkgName: String = service.getFile.scalaPackage.fullName.stripPrefix("_root_.")
 
   protected def serviceMethodSignature(method: MethodDescriptor): String
 

--- a/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2Grpc.scala.txt
@@ -8,21 +8,21 @@ import _root_.cats.syntax.all._
 trait TestServiceFs2Grpc[F[_], A] {
   /** Unary RPC: no streaming in either direction
     */
-  def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage]
+  def noStreaming(request: _root_.hello.world.TestMessage, ctx: A): F[_root_.hello.world.TestMessage]
   /** Client streaming RPC: client streams, server returns a single response
     */
-  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage]
+  def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): F[_root_.hello.world.TestMessage]
   /** Server streaming RPC: client sends one request, server streams responses
     */
-  def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def serverStreaming(request: _root_.hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
   /** Bidirectional streaming RPC: both client and server stream
     */
-  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
 }
 
 object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2Grpc] {
   
-  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = _root_.hello.world.TestServiceGrpc.SERVICE
   
   def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
     dispatcher: _root_.cats.effect.std.Dispatcher[G],
@@ -30,29 +30,29 @@ object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestService
     clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
     clientOptions: _root_.fs2.grpc.client.ClientOptions
   ): TestServiceFs2Grpc[F, A] = new TestServiceFs2Grpc[F, A] {
-    def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage] =
-      clientAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+    def noStreaming(request: _root_.hello.world.TestMessage, ctx: A): F[_root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
       )
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage] =
-      clientAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+    def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): F[_root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
       )
-    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+    def serverStreaming(request: _root_.hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
       )
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+    def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
       )
   }
   
@@ -63,42 +63,42 @@ object TestServiceFs2Grpc extends _root_.fs2.grpc.GeneratedCompanion[TestService
     serverOptions: _root_.fs2.grpc.server.ServerOptions
   ) = {
     _root_.io.grpc.ServerServiceDefinition
-      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .builder(_root_.hello.world.TestServiceGrpc.SERVICE)
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
             r,
             (r, m) => serviceImpl.noStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
             r,
             (r, m) => serviceImpl.clientStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
             r,
             (r, m) => serviceImpl.serverStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
             r,
             (r, m) => serviceImpl.bothStreaming(r, m)
           )

--- a/e2e/src/test/resources/TestServiceFs2GrpcDisableTrailers.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcDisableTrailers.scala.txt
@@ -8,21 +8,21 @@ import _root_.cats.syntax.all._
 trait TestServiceFs2GrpcDisableTrailers[F[_], A] {
   /** Unary RPC: no streaming in either direction
     */
-  def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage]
+  def noStreaming(request: _root_.hello.world.TestMessage, ctx: A): F[_root_.hello.world.TestMessage]
   /** Client streaming RPC: client streams, server returns a single response
     */
-  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage]
+  def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): F[_root_.hello.world.TestMessage]
   /** Server streaming RPC: client sends one request, server streams responses
     */
-  def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def serverStreaming(request: _root_.hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
   /** Bidirectional streaming RPC: both client and server stream
     */
-  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
 }
 
 object TestServiceFs2GrpcDisableTrailers extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcDisableTrailers] {
   
-  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = _root_.hello.world.TestServiceGrpc.SERVICE
   
   def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
     dispatcher: _root_.cats.effect.std.Dispatcher[G],
@@ -30,29 +30,29 @@ object TestServiceFs2GrpcDisableTrailers extends _root_.fs2.grpc.GeneratedCompan
     clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
     clientOptions: _root_.fs2.grpc.client.ClientOptions
   ): TestServiceFs2GrpcDisableTrailers[F, A] = new TestServiceFs2GrpcDisableTrailers[F, A] {
-    def noStreaming(request: hello.world.TestMessage, ctx: A): F[hello.world.TestMessage] =
-      clientAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+    def noStreaming(request: _root_.hello.world.TestMessage, ctx: A): F[_root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
       )
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[hello.world.TestMessage] =
-      clientAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+    def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): F[_root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
       )
-    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+    def serverStreaming(request: _root_.hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
       )
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+    def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
       )
   }
   
@@ -63,42 +63,42 @@ object TestServiceFs2GrpcDisableTrailers extends _root_.fs2.grpc.GeneratedCompan
     serverOptions: _root_.fs2.grpc.server.ServerOptions
   ) = {
     _root_.io.grpc.ServerServiceDefinition
-      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .builder(_root_.hello.world.TestServiceGrpc.SERVICE)
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
             r,
             (r, m) => serviceImpl.noStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
             r,
             (r, m) => serviceImpl.clientStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
             r,
             (r, m) => serviceImpl.serverStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
             r,
             (r, m) => serviceImpl.bothStreaming(r, m)
           )

--- a/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicit.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicit.scala.txt
@@ -8,21 +8,21 @@ import _root_.cats.syntax.all._
 trait TestServiceFs2GrpcRenderContextAsImplicit[F[_], A] {
   /** Unary RPC: no streaming in either direction
     */
-  def noStreaming(request: hello.world.TestMessage)(implicit ctx: A): F[hello.world.TestMessage]
+  def noStreaming(request: _root_.hello.world.TestMessage)(implicit ctx: A): F[_root_.hello.world.TestMessage]
   /** Client streaming RPC: client streams, server returns a single response
     */
-  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): F[hello.world.TestMessage]
+  def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(implicit ctx: A): F[_root_.hello.world.TestMessage]
   /** Server streaming RPC: client sends one request, server streams responses
     */
-  def serverStreaming(request: hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def serverStreaming(request: _root_.hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
   /** Bidirectional streaming RPC: both client and server stream
     */
-  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
 }
 
 object TestServiceFs2GrpcRenderContextAsImplicit extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicit] {
   
-  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = _root_.hello.world.TestServiceGrpc.SERVICE
   
   def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
     dispatcher: _root_.cats.effect.std.Dispatcher[G],
@@ -30,29 +30,29 @@ object TestServiceFs2GrpcRenderContextAsImplicit extends _root_.fs2.grpc.Generat
     clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
     clientOptions: _root_.fs2.grpc.client.ClientOptions
   ): TestServiceFs2GrpcRenderContextAsImplicit[F, A] = new TestServiceFs2GrpcRenderContextAsImplicit[F, A] {
-    def noStreaming(request: hello.world.TestMessage)(implicit ctx: A): F[hello.world.TestMessage] =
-      clientAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+    def noStreaming(request: _root_.hello.world.TestMessage)(implicit ctx: A): F[_root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
       )
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): F[hello.world.TestMessage] =
-      clientAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+    def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(implicit ctx: A): F[_root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
       )
-    def serverStreaming(request: hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+    def serverStreaming(request: _root_.hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
       )
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+    def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
       )
   }
   
@@ -63,42 +63,42 @@ object TestServiceFs2GrpcRenderContextAsImplicit extends _root_.fs2.grpc.Generat
     serverOptions: _root_.fs2.grpc.server.ServerOptions
   ) = {
     _root_.io.grpc.ServerServiceDefinition
-      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .builder(_root_.hello.world.TestServiceGrpc.SERVICE)
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
             r,
             (r, m) => serviceImpl.noStreaming(r)(m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
             r,
             (r, m) => serviceImpl.clientStreaming(r)(m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
             r,
             (r, m) => serviceImpl.serverStreaming(r)(m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
             r,
             (r, m) => serviceImpl.bothStreaming(r)(m)
           )

--- a/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitScala3.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitScala3.scala.txt
@@ -8,21 +8,21 @@ import _root_.cats.syntax.all.*
 trait TestServiceFs2GrpcRenderContextAsImplicit[F[_], A] {
   /** Unary RPC: no streaming in either direction
     */
-  def noStreaming(request: hello.world.TestMessage)(using ctx: A): F[hello.world.TestMessage]
+  def noStreaming(request: _root_.hello.world.TestMessage)(using ctx: A): F[_root_.hello.world.TestMessage]
   /** Client streaming RPC: client streams, server returns a single response
     */
-  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): F[hello.world.TestMessage]
+  def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(using ctx: A): F[_root_.hello.world.TestMessage]
   /** Server streaming RPC: client sends one request, server streams responses
     */
-  def serverStreaming(request: hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def serverStreaming(request: _root_.hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
   /** Bidirectional streaming RPC: both client and server stream
     */
-  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
 }
 
 object TestServiceFs2GrpcRenderContextAsImplicit extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicit] {
   
-  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = _root_.hello.world.TestServiceGrpc.SERVICE
   
   def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
     dispatcher: _root_.cats.effect.std.Dispatcher[G],
@@ -30,29 +30,29 @@ object TestServiceFs2GrpcRenderContextAsImplicit extends _root_.fs2.grpc.Generat
     clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
     clientOptions: _root_.fs2.grpc.client.ClientOptions
   ): TestServiceFs2GrpcRenderContextAsImplicit[F, A] = new TestServiceFs2GrpcRenderContextAsImplicit[F, A] {
-    def noStreaming(request: hello.world.TestMessage)(using ctx: A): F[hello.world.TestMessage] =
-      clientAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+    def noStreaming(request: _root_.hello.world.TestMessage)(using ctx: A): F[_root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCall(req, m))
       )
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): F[hello.world.TestMessage] =
-      clientAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+    def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(using ctx: A): F[_root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCall(req, m))
       )
-    def serverStreaming(request: hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+    def serverStreaming(request: _root_.hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
       )
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+    def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
       )
   }
   
@@ -63,42 +63,42 @@ object TestServiceFs2GrpcRenderContextAsImplicit extends _root_.fs2.grpc.Generat
     serverOptions: _root_.fs2.grpc.server.ServerOptions
   ) = {
     _root_.io.grpc.ServerServiceDefinition
-      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .builder(_root_.hello.world.TestServiceGrpc.SERVICE)
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
             r,
             (r, m) => serviceImpl.noStreaming(r)(using m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToUnaryCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
             r,
             (r, m) => serviceImpl.clientStreaming(r)(using m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
             r,
             (r, m) => serviceImpl.serverStreaming(r)(using m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
             r,
             (r, m) => serviceImpl.bothStreaming(r)(using m)
           )

--- a/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitTrailers.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitTrailers.scala.txt
@@ -8,21 +8,21 @@ import _root_.cats.syntax.all._
 trait TestServiceFs2GrpcRenderContextAsImplicitTrailers[F[_], A] {
   /** Unary RPC: no streaming in either direction
     */
-  def noStreaming(request: hello.world.TestMessage)(implicit ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  def noStreaming(request: _root_.hello.world.TestMessage)(implicit ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)]
   /** Client streaming RPC: client streams, server returns a single response
     */
-  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(implicit ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)]
   /** Server streaming RPC: client sends one request, server streams responses
     */
-  def serverStreaming(request: hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def serverStreaming(request: _root_.hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
   /** Bidirectional streaming RPC: both client and server stream
     */
-  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
 }
 
 object TestServiceFs2GrpcRenderContextAsImplicitTrailers extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicitTrailers] {
   
-  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = _root_.hello.world.TestServiceGrpc.SERVICE
   
   def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
     dispatcher: _root_.cats.effect.std.Dispatcher[G],
@@ -30,29 +30,29 @@ object TestServiceFs2GrpcRenderContextAsImplicitTrailers extends _root_.fs2.grpc
     clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
     clientOptions: _root_.fs2.grpc.client.ClientOptions
   ): TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A] = new TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A] {
-    def noStreaming(request: hello.world.TestMessage)(implicit ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
-      clientAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+    def noStreaming(request: _root_.hello.world.TestMessage)(implicit ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitUnaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
       )
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
-      clientAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+    def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(implicit ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitStreamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
       )
-    def serverStreaming(request: hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+    def serverStreaming(request: _root_.hello.world.TestMessage)(implicit ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
       )
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+    def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(implicit ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
       )
   }
   
@@ -63,42 +63,42 @@ object TestServiceFs2GrpcRenderContextAsImplicitTrailers extends _root_.fs2.grpc
     serverOptions: _root_.fs2.grpc.server.ServerOptions
   ) = {
     _root_.io.grpc.ServerServiceDefinition
-      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .builder(_root_.hello.world.TestServiceGrpc.SERVICE)
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
             r,
             (r, m) => serviceImpl.noStreaming(r)(m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
             r,
             (r, m) => serviceImpl.clientStreaming(r)(m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
             r,
             (r, m) => serviceImpl.serverStreaming(r)(m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
             r,
             (r, m) => serviceImpl.bothStreaming(r)(m)
           )

--- a/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitTrailersScala3.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcRenderContextAsImplicitTrailersScala3.scala.txt
@@ -8,21 +8,21 @@ import _root_.cats.syntax.all.*
 trait TestServiceFs2GrpcRenderContextAsImplicitTrailers[F[_], A] {
   /** Unary RPC: no streaming in either direction
     */
-  def noStreaming(request: hello.world.TestMessage)(using ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  def noStreaming(request: _root_.hello.world.TestMessage)(using ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)]
   /** Client streaming RPC: client streams, server returns a single response
     */
-  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(using ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)]
   /** Server streaming RPC: client sends one request, server streams responses
     */
-  def serverStreaming(request: hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def serverStreaming(request: _root_.hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
   /** Bidirectional streaming RPC: both client and server stream
     */
-  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
 }
 
 object TestServiceFs2GrpcRenderContextAsImplicitTrailers extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcRenderContextAsImplicitTrailers] {
   
-  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = _root_.hello.world.TestServiceGrpc.SERVICE
   
   def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
     dispatcher: _root_.cats.effect.std.Dispatcher[G],
@@ -30,29 +30,29 @@ object TestServiceFs2GrpcRenderContextAsImplicitTrailers extends _root_.fs2.grpc
     clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
     clientOptions: _root_.fs2.grpc.client.ClientOptions
   ): TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A] = new TestServiceFs2GrpcRenderContextAsImplicitTrailers[F, A] {
-    def noStreaming(request: hello.world.TestMessage)(using ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
-      clientAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+    def noStreaming(request: _root_.hello.world.TestMessage)(using ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitUnaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
       )
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
-      clientAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+    def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(using ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitStreamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
       )
-    def serverStreaming(request: hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+    def serverStreaming(request: _root_.hello.world.TestMessage)(using ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
       )
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+    def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage])(using ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
       )
   }
   
@@ -63,42 +63,42 @@ object TestServiceFs2GrpcRenderContextAsImplicitTrailers extends _root_.fs2.grpc
     serverOptions: _root_.fs2.grpc.server.ServerOptions
   ) = {
     _root_.io.grpc.ServerServiceDefinition
-      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .builder(_root_.hello.world.TestServiceGrpc.SERVICE)
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
             r,
             (r, m) => serviceImpl.noStreaming(r)(using m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
             r,
             (r, m) => serviceImpl.clientStreaming(r)(using m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
             r,
             (r, m) => serviceImpl.serverStreaming(r)(using m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
             r,
             (r, m) => serviceImpl.bothStreaming(r)(using m)
           )

--- a/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
+++ b/e2e/src/test/resources/TestServiceFs2GrpcTrailers.scala.txt
@@ -8,21 +8,21 @@ import _root_.cats.syntax.all._
 trait TestServiceFs2GrpcTrailers[F[_], A] {
   /** Unary RPC: no streaming in either direction
     */
-  def noStreaming(request: hello.world.TestMessage, ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  def noStreaming(request: _root_.hello.world.TestMessage, ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)]
   /** Client streaming RPC: client streams, server returns a single response
     */
-  def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)]
+  def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)]
   /** Server streaming RPC: client sends one request, server streams responses
     */
-  def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def serverStreaming(request: _root_.hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
   /** Bidirectional streaming RPC: both client and server stream
     */
-  def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage]
+  def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage]
 }
 
 object TestServiceFs2GrpcTrailers extends _root_.fs2.grpc.GeneratedCompanion[TestServiceFs2GrpcTrailers] {
   
-  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = hello.world.TestServiceGrpc.SERVICE
+  def serviceDescriptor: _root_.io.grpc.ServiceDescriptor = _root_.hello.world.TestServiceGrpc.SERVICE
   
   def mkClientFull[F[_], G[_]: _root_.cats.effect.Async, A](
     dispatcher: _root_.cats.effect.std.Dispatcher[G],
@@ -30,29 +30,29 @@ object TestServiceFs2GrpcTrailers extends _root_.fs2.grpc.GeneratedCompanion[Tes
     clientAspect: _root_.fs2.grpc.client.ClientAspect[F, G, A],
     clientOptions: _root_.fs2.grpc.client.ClientOptions
   ): TestServiceFs2GrpcTrailers[F, A] = new TestServiceFs2GrpcTrailers[F, A] {
-    def noStreaming(request: hello.world.TestMessage, ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
-      clientAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+    def noStreaming(request: _root_.hello.world.TestMessage, ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitUnaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING, dispatcher, clientOptions).flatMap(_.unaryToUnaryCallTrailers(req, m))
       )
-    def clientStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): F[(hello.world.TestMessage, _root_.io.grpc.Metadata)] =
-      clientAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+    def clientStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): F[(_root_.hello.world.TestMessage, _root_.io.grpc.Metadata)] =
+      clientAspect.visitStreamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
         request,
-        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
+        (req, m) => _root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING, dispatcher, clientOptions).flatMap(_.streamingToUnaryCallTrailers(req, m))
       )
-    def serverStreaming(request: hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+    def serverStreaming(request: _root_.hello.world.TestMessage, ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING, dispatcher, clientOptions)).flatMap(_.unaryToStreamingCall(req, m))
       )
-    def bothStreaming(request: _root_.fs2.Stream[F, hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, hello.world.TestMessage] =
-      clientAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-        _root_.fs2.grpc.client.ClientCallContext(ctx, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+    def bothStreaming(request: _root_.fs2.Stream[F, _root_.hello.world.TestMessage], ctx: A): _root_.fs2.Stream[F, _root_.hello.world.TestMessage] =
+      clientAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+        _root_.fs2.grpc.client.ClientCallContext(ctx, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
         request,
-        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
+        (req, m) => _root_.fs2.Stream.eval(_root_.fs2.grpc.client.Fs2ClientCall[G](channel, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING, dispatcher, clientOptions)).flatMap(_.streamingToStreamingCall(req, m))
       )
   }
   
@@ -63,42 +63,42 @@ object TestServiceFs2GrpcTrailers extends _root_.fs2.grpc.GeneratedCompanion[Tes
     serverOptions: _root_.fs2.grpc.server.ServerOptions
   ) = {
     _root_.io.grpc.ServerServiceDefinition
-      .builder(hello.world.TestServiceGrpc.SERVICE)
+      .builder(_root_.hello.world.TestServiceGrpc.SERVICE)
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_NO_STREAMING),
             r,
             (r, m) => serviceImpl.noStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToUnaryCallTrailers[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToUnaryCallTrailers[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_CLIENT_STREAMING),
             r,
             (r, m) => serviceImpl.clientStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitUnaryToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).unaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitUnaryToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_SERVER_STREAMING),
             r,
             (r, m) => serviceImpl.serverStreaming(r, m)
           )
         }
       )
       .addMethod(
-        hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
-        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage]{ (r, m) => 
-          serviceAspect.visitStreamingToStreamingCall[hello.world.TestMessage, hello.world.TestMessage](
-            _root_.fs2.grpc.server.ServiceCallContext(m, hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
+        _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING,
+        _root_.fs2.grpc.server.Fs2ServerCallHandler[G](dispatcher, serverOptions).streamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage]{ (r, m) => 
+          serviceAspect.visitStreamingToStreamingCall[_root_.hello.world.TestMessage, _root_.hello.world.TestMessage](
+            _root_.fs2.grpc.server.ServiceCallContext(m, _root_.hello.world.TestServiceGrpc.METHOD_BOTH_STREAMING),
             r,
             (r, m) => serviceImpl.bothStreaming(r, m)
           )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,4 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.8") // Because sbt-protoc-gen-project brings in 1.0.4
 addSbtPlugin("com.thesamet" % "sbt-protoc-gen-project" % "0.1.8")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.20"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "1.0.0-alpha.3"


### PR DESCRIPTION
In the new ScalaPB, symbols are returned with _root_ prefixes and (for scala 3) and `using` keywords are inserted. Because of that, related tests were adjusted and we filter out `_root_` from packages (since it's an illegal name there).

This is part PR, part question, since I realize there's an `alpha` in the version name - is it possible to merge this? Or merge into some branch and release via some separate/temporary version scheme?

The reason for needing this is that there is some incompatibility when migrating a project to Bazel 8, caused by a necessary rules_java upgrade, which itself enforces a newer protobuf version.  Regardless of the reason, I think it would be helpful to get this in.