### PR TITLE
Add configurable shutdown timeout for server/client resources and streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ inThisBuild(
   List(
     githubWorkflowBuildSbtStepPreamble := Seq(),
     scalaVersion := Scala3,
-    tlBaseVersion := "3.0",
+    tlBaseVersion := "3.1",
     startYear := Some(2018),
     licenses := Seq(("MIT", url("https://github.com/typelevel/fs2-grpc/blob/master/LICENSE"))),
     organizationName := "Gary Coady / Fs2 Grpc Developers",

--- a/e2e-otel4s/src/test/scala/fs2/grpc/e2e/otel4s/TraceAspectSuite.scala
+++ b/e2e-otel4s/src/test/scala/fs2/grpc/e2e/otel4s/TraceAspectSuite.scala
@@ -51,6 +51,8 @@ import org.typelevel.otel4s.semconv.experimental.attributes.RpcExperimentalAttri
 import org.typelevel.otel4s.trace.{SpanContext, SpanKind, Tracer}
 import org.typelevel.otel4s.{Attribute, Attributes}
 
+import scala.concurrent.duration._
+
 class TraceAspectSuite extends CatsEffectSuite {
 
   withFixture("follow request's span") { fixture =>
@@ -500,10 +502,10 @@ class TraceAspectSuite extends CatsEffectSuite {
     InProcessServerBuilder
       .forName(id)
       .addService(xs)
-      .resource[IO]
+      .resource[IO](30.seconds)
       .evalTap(s => IO.delay(s.start()))
 
   private def bindClientChannel(id: String): Resource[IO, Channel] =
-    InProcessChannelBuilder.forName(id).usePlaintext().resource[IO]
+    InProcessChannelBuilder.forName(id).usePlaintext().resource[IO](30.seconds)
 
 }

--- a/e2e-otel4s/src/test/scala/fs2/grpc/e2e/otel4s/TraceAspectSuite.scala
+++ b/e2e-otel4s/src/test/scala/fs2/grpc/e2e/otel4s/TraceAspectSuite.scala
@@ -502,10 +502,10 @@ class TraceAspectSuite extends CatsEffectSuite {
     InProcessServerBuilder
       .forName(id)
       .addService(xs)
-      .resource[IO](30.seconds)
+      .resourceWithShutdownTimeout[IO](30.seconds)
       .evalTap(s => IO.delay(s.start()))
 
   private def bindClientChannel(id: String): Resource[IO, Channel] =
-    InProcessChannelBuilder.forName(id).usePlaintext().resource[IO](30.seconds)
+    InProcessChannelBuilder.forName(id).usePlaintext().resourceWithShutdownTimeout[IO](30.seconds)
 
 }

--- a/runtime/src/main/scala/fs2/grpc/syntax/AllSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/AllSyntax.scala
@@ -23,4 +23,8 @@ package fs2
 package grpc
 package syntax
 
-trait AllSyntax extends ManagedChannelBuilderSyntax with ServerBuilderSyntax
+trait AllSyntax
+    extends ManagedChannelBuilderSyntax
+    with ServerBuilderSyntax
+    with ManagedChannelBuilderTimeoutSyntax
+    with ServerBuilderResourceTimeoutSyntax

--- a/runtime/src/main/scala/fs2/grpc/syntax/AllSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/AllSyntax.scala
@@ -25,6 +25,6 @@ package syntax
 
 trait AllSyntax
     extends ManagedChannelBuilderSyntax
-    with ServerBuilderSyntax
     with ManagedChannelBuilderTimeoutSyntax
+    with ServerBuilderSyntax
     with ServerBuilderResourceTimeoutSyntax

--- a/runtime/src/main/scala/fs2/grpc/syntax/ManagedChannelBuilderSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/ManagedChannelBuilderSyntax.scala
@@ -44,7 +44,7 @@ final class ManagedChannelBuilderOps[MCB <: ManagedChannelBuilder[MCB]](val buil
     *   i. We block for up to 30 seconds on termination, using the blocking context
     *   i. If the channel is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
+    * For different tradeoffs in shutdown behavior, see [[resourceWithShutdown]].
     */
   def resource[F[_]](implicit F: Sync[F]): Resource[F, ManagedChannel] =
     resourceWithShutdown { ch =>
@@ -73,7 +73,7 @@ final class ManagedChannelBuilderOps[MCB <: ManagedChannelBuilder[MCB]](val buil
     *   i. We block for up to 30 seconds on termination, using the blocking context
     *   i. If the channel is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+    * For different tradeoffs in shutdown behavior, see [[streamWithShutdown]].
     */
   def stream[F[_]](implicit F: Async[F]): Stream[F, ManagedChannel] =
     Stream.resource(resource[F])

--- a/runtime/src/main/scala/fs2/grpc/syntax/ManagedChannelBuilderTimeoutSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/ManagedChannelBuilderTimeoutSyntax.scala
@@ -24,66 +24,53 @@ package grpc
 package syntax
 
 import java.util.concurrent.TimeUnit
+
 import cats.effect._
 import cats.syntax.all._
+import fs2.grpc.syntax.managedChannelBuilder._
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 
-trait ManagedChannelBuilderSyntax {
-  implicit final def fs2GrpcSyntaxManagedChannelBuilder[MCB <: ManagedChannelBuilder[MCB]](
+import scala.concurrent.duration.FiniteDuration
+
+trait ManagedChannelBuilderTimeoutSyntax {
+  implicit final def fs2GrpcSyntaxManagedChannelBuilderTimeout[MCB <: ManagedChannelBuilder[MCB]](
       builder: MCB
-  ): ManagedChannelBuilderOps[MCB] =
-    new ManagedChannelBuilderOps[MCB](builder)
+  ): ManagedChannelBuilderTimeoutOps[MCB] =
+    new ManagedChannelBuilderTimeoutOps[MCB](builder)
 }
 
-final class ManagedChannelBuilderOps[MCB <: ManagedChannelBuilder[MCB]](val builder: MCB) extends AnyVal {
+final class ManagedChannelBuilderTimeoutOps[MCB <: ManagedChannelBuilder[MCB]](val builder: MCB) extends AnyVal {
 
   /** Builds a `ManagedChannel` into a resource. The managed channel is shut down when the resource is released.
     * Shutdown is as follows:
     *
     *   i. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls.
-    *   i. We block for up to 30 seconds on termination, using the blocking context
+    *   i. We block for up to {timeout} on termination, using the blocking context
     *   i. If the channel is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
+    * @param timeout
+    *   the duration of the timeout
     */
-  def resource[F[_]](implicit F: Sync[F]): Resource[F, ManagedChannel] =
-    resourceWithShutdown { ch =>
+  def resource[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, ManagedChannel] =
+    builder.resourceWithShutdown { ch =>
       for {
         _ <- F.delay(ch.shutdown())
-        terminated <- F.interruptible(ch.awaitTermination(30, TimeUnit.SECONDS))
+        terminated <- F.interruptible(ch.awaitTermination(timeout.toSeconds, TimeUnit.SECONDS))
         _ <- F.unlessA(terminated)(F.delay(ch.shutdownNow()))
-      } yield (())
+      } yield ()
     }
-
-  /** Builds a `ManagedChannel` into a resource. The managed channel is shut down when the resource is released.
-    *
-    * @param shutdown
-    *   Determines the behavior of the cleanup of the managed channel, with respect to forceful vs. graceful shutdown
-    *   and how to poll or block for termination.
-    */
-  def resourceWithShutdown[F[_]](
-      shutdown: ManagedChannel => F[Unit]
-  )(implicit F: Sync[F]): Resource[F, ManagedChannel] =
-    Resource.make(F.delay(builder.build()))(shutdown)
 
   /** Builds a `ManagedChannel` into a stream. The managed channel is shut down when the stream is complete. Shutdown is
     * as follows:
     *
     *   i. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls.
-    *   i. We block for up to 30 seconds on termination, using the blocking context
+    *   i. We block for up to {timeout} on termination, using the blocking context
     *   i. If the channel is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+    * @param timeout
+    *   the duration of the timeout
     */
-  def stream[F[_]](implicit F: Async[F]): Stream[F, ManagedChannel] =
-    Stream.resource(resource[F])
+  def stream[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, ManagedChannel] =
+    Stream.resource(resource[F](timeout))
 
-  /** Builds a `ManagedChannel` into a stream. The managed channel is shut down when the stream is complete.
-    *
-    * @param shutdown
-    *   Determines the behavior of the cleanup of the managed channel, with respect to forceful vs. graceful shutdown
-    *   and how to poll or block for termination.
-    */
-  def streamWithShutdown[F[_]](shutdown: ManagedChannel => F[Unit])(implicit F: Async[F]): Stream[F, ManagedChannel] =
-    Stream.resource(resourceWithShutdown(shutdown))
 }

--- a/runtime/src/main/scala/fs2/grpc/syntax/ManagedChannelBuilderTimeoutSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/ManagedChannelBuilderTimeoutSyntax.scala
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect._
 import cats.syntax.all._
-import fs2.grpc.syntax.managedChannelBuilder._
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 
 import scala.concurrent.duration.FiniteDuration
@@ -51,8 +50,8 @@ final class ManagedChannelBuilderTimeoutOps[MCB <: ManagedChannelBuilder[MCB]](v
     * @param timeout
     *   the duration of the timeout
     */
-  def resource[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, ManagedChannel] =
-    builder.resourceWithShutdown { ch =>
+  def resourceWithShutdownTimeout[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, ManagedChannel] =
+    new ManagedChannelBuilderOps[MCB](builder).resourceWithShutdown { ch =>
       for {
         _ <- F.delay(ch.shutdown())
         terminated <- F.interruptible(ch.awaitTermination(timeout.toSeconds, TimeUnit.SECONDS))
@@ -70,7 +69,7 @@ final class ManagedChannelBuilderTimeoutOps[MCB <: ManagedChannelBuilder[MCB]](v
     * @param timeout
     *   the duration of the timeout
     */
-  def stream[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, ManagedChannel] =
-    Stream.resource(resource[F](timeout))
+  def streamWithShutdownTimeout[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, ManagedChannel] =
+    Stream.resource(resourceWithShutdownTimeout[F](timeout))
 
 }

--- a/runtime/src/main/scala/fs2/grpc/syntax/ServerBuilderResourceTimeoutSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/ServerBuilderResourceTimeoutSyntax.scala
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit
 import cats.effect._
 import cats.syntax.all._
 import io.grpc.{Server, ServerBuilder}
-import fs2.grpc.syntax.serverBuilder._
 
 import scala.concurrent.duration._
 
@@ -49,8 +48,8 @@ final class ServerBuilderResourceTimeoutOps[SB <: ServerBuilder[SB]](val builder
     * @param timeout
     *   the duration of the timeout
     */
-  def resource[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, Server] =
-    builder.resourceWithShutdown { server =>
+  def resourceWithShutdownTimeout[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, Server] =
+    new ServerBuilderOps[SB](builder).resourceWithShutdown { server =>
       for {
         _ <- F.delay(server.shutdown())
         terminated <- F.interruptible(server.awaitTermination(timeout.toSeconds, TimeUnit.SECONDS))
@@ -67,7 +66,7 @@ final class ServerBuilderResourceTimeoutOps[SB <: ServerBuilder[SB]](val builder
     * @param timeout
     *   the duration of the timeout
     */
-  def stream[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, Server] =
-    Stream.resource(resource[F](timeout))
+  def streamWithShutdownTimeout[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, Server] =
+    Stream.resource(resourceWithShutdownTimeout[F](timeout))
 
 }

--- a/runtime/src/main/scala/fs2/grpc/syntax/ServerBuilderResourceTimeoutSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/ServerBuilderResourceTimeoutSyntax.scala
@@ -27,57 +27,47 @@ import java.util.concurrent.TimeUnit
 import cats.effect._
 import cats.syntax.all._
 import io.grpc.{Server, ServerBuilder}
+import fs2.grpc.syntax.serverBuilder._
 
-trait ServerBuilderSyntax {
-  implicit final def fs2GrpcSyntaxServerBuilder[SB <: ServerBuilder[SB]](builder: SB): ServerBuilderOps[SB] =
-    new ServerBuilderOps[SB](builder)
+import scala.concurrent.duration._
+
+trait ServerBuilderResourceTimeoutSyntax {
+  implicit final def fs2GrpcSyntaxServerBuilderResourceTimeout[SB <: ServerBuilder[SB]](
+      builder: SB
+  ): ServerBuilderResourceTimeoutOps[SB] =
+    new ServerBuilderResourceTimeoutOps[SB](builder)
 }
 
-final class ServerBuilderOps[SB <: ServerBuilder[SB]](val builder: SB) extends AnyVal {
+final class ServerBuilderResourceTimeoutOps[SB <: ServerBuilder[SB]](val builder: SB) extends AnyVal {
 
   /** Builds a `Server` into a resource. The server is shut down when the resource is released. Shutdown is as follows:
     *
     *   i. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls.
-    *   i. We block for up to 30 seconds on termination, using the blocking context
+    *   i. We block for up to {timeout} on termination, using the blocking context
     *   i. If the server is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see [[resourceWithShutdown]].
+    * @param timeout
+    *   the duration of the timeout
     */
-  def resource[F[_]](implicit F: Sync[F]): Resource[F, Server] =
-    resourceWithShutdown { server =>
+  def resource[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, Server] =
+    builder.resourceWithShutdown { server =>
       for {
         _ <- F.delay(server.shutdown())
-        terminated <- F.interruptible(server.awaitTermination(30, TimeUnit.SECONDS))
+        terminated <- F.interruptible(server.awaitTermination(timeout.toSeconds, TimeUnit.SECONDS))
         _ <- F.unlessA(terminated)(F.delay(server.shutdownNow()))
-      } yield (())
+      } yield ()
     }
-
-  /** Builds a `Server` into a resource. The server is shut down when the resource is released.
-    *
-    * @param shutdown
-    *   Determines the behavior of the cleanup of the server, with respect to forceful vs. graceful shutdown and how to
-    *   poll or block for termination.
-    */
-  def resourceWithShutdown[F[_]](shutdown: Server => F[Unit])(implicit F: Sync[F]): Resource[F, Server] =
-    Resource.make(F.delay(builder.build()))(shutdown)
 
   /** Builds a `Server` into a stream. The server is shut down when the stream is complete. Shutdown is as follows:
     *
     *   i. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls.
-    *   i. We block for up to 30 seconds on termination, using the blocking context
+    *   i. We block for up to {timeout} on termination, using the blocking context
     *   i. If the server is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see [[streamWithShutdown]].
+    * @param timeout
+    *   the duration of the timeout
     */
-  def stream[F[_]](implicit F: Async[F]): Stream[F, Server] =
-    Stream.resource(resource[F])
+  def stream[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, Server] =
+    Stream.resource(resource[F](timeout))
 
-  /** Builds a `Server` into a stream. The server is shut down when the stream is complete.
-    *
-    * @param shutdown
-    *   Determines the behavior of the cleanup of the server, with respect to forceful vs. graceful shutdown and how to
-    *   poll or block for termination.
-    */
-  def streamWithShutdown[F[_]](shutdown: Server => F[Unit])(implicit F: Async[F]): Stream[F, Server] =
-    Stream.resource(resourceWithShutdown(shutdown))
 }

--- a/runtime/src/main/scala/fs2/grpc/syntax/ServerBuilderSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/ServerBuilderSyntax.scala
@@ -44,12 +44,9 @@ final class ServerBuilderOps[SB <: ServerBuilder[SB]](val builder: SB) extends A
     *   i. If the server is not yet terminated, we trigger a forceful shutdown
     *
     * For different tradeoffs in shutdown behavior, see [[resourceWithShutdown]].
-    *
-    * @see
-    *   [[resourceWithShutdownTimeout]] to explicitly set the timeout
     */
   def resource[F[_]](implicit F: Sync[F]): Resource[F, Server] =
-    resourceWithShutdownTimeout(30.seconds)
+    resource(30.seconds)
 
   /** Builds a `Server` into a resource. The server is shut down when the resource is released. Shutdown is as follows:
     *
@@ -62,7 +59,7 @@ final class ServerBuilderOps[SB <: ServerBuilder[SB]](val builder: SB) extends A
     * @param timeout
     *   the duration of the timeout
     */
-  def resourceWithShutdownTimeout[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, Server] =
+  def resource[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, Server] =
     resourceWithShutdown { server =>
       for {
         _ <- F.delay(server.shutdown())
@@ -87,9 +84,6 @@ final class ServerBuilderOps[SB <: ServerBuilder[SB]](val builder: SB) extends A
     *   i. If the server is not yet terminated, we trigger a forceful shutdown
     *
     * For different tradeoffs in shutdown behavior, see [[streamWithShutdown]].
-    *
-    * @see
-    *   [[streamWithShutdownTimeout]] to explicitly set the timeout
     */
   def stream[F[_]](implicit F: Async[F]): Stream[F, Server] =
     Stream.resource(resource[F])
@@ -101,9 +95,12 @@ final class ServerBuilderOps[SB <: ServerBuilder[SB]](val builder: SB) extends A
     *   i. If the server is not yet terminated, we trigger a forceful shutdown
     *
     * For different tradeoffs in shutdown behavior, see [[streamWithShutdown]].
+    *
+    * @param timeout
+    *   the duration of the timeout
     */
-  def streamWithShutdownTimeout[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, Server] =
-    Stream.resource(resourceWithShutdownTimeout[F](timeout))
+  def stream[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, Server] =
+    Stream.resource(resource[F](timeout))
 
   /** Builds a `Server` into a stream. The server is shut down when the stream is complete.
     *

--- a/runtime/src/main/scala/fs2/grpc/syntax/ServerBuilderSyntax.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/ServerBuilderSyntax.scala
@@ -28,6 +28,8 @@ import cats.effect._
 import cats.syntax.all._
 import io.grpc.{Server, ServerBuilder}
 
+import scala.concurrent.duration._
+
 trait ServerBuilderSyntax {
   implicit final def fs2GrpcSyntaxServerBuilder[SB <: ServerBuilder[SB]](builder: SB): ServerBuilderOps[SB] =
     new ServerBuilderOps[SB](builder)
@@ -37,17 +39,34 @@ final class ServerBuilderOps[SB <: ServerBuilder[SB]](val builder: SB) extends A
 
   /** Builds a `Server` into a resource. The server is shut down when the resource is released. Shutdown is as follows:
     *
-    *   1. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls. 2. We
-    *      block for up to 30 seconds on termination, using the blocking context 3. If the server is not yet terminated,
-    *      we trigger a forceful shutdown
+    *   i. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls.
+    *   i. We block for up to 30 seconds on termination, using the blocking context
+    *   i. If the server is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see {{resourceWithShutdown}}.
+    * For different tradeoffs in shutdown behavior, see [[resourceWithShutdown]].
+    *
+    * @see
+    *   [[resourceWithShutdownTimeout]] to explicitly set the timeout
     */
   def resource[F[_]](implicit F: Sync[F]): Resource[F, Server] =
+    resourceWithShutdownTimeout(30.seconds)
+
+  /** Builds a `Server` into a resource. The server is shut down when the resource is released. Shutdown is as follows:
+    *
+    *   i. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls.
+    *   i. We block for up to {timeout} on termination, using the blocking context
+    *   i. If the server is not yet terminated, we trigger a forceful shutdown
+    *
+    * For different tradeoffs in shutdown behavior, see [[resourceWithShutdown]].
+    *
+    * @param timeout
+    *   the duration of the timeout
+    */
+  def resourceWithShutdownTimeout[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Resource[F, Server] =
     resourceWithShutdown { server =>
       for {
         _ <- F.delay(server.shutdown())
-        terminated <- F.interruptible(server.awaitTermination(30, TimeUnit.SECONDS))
+        terminated <- F.interruptible(server.awaitTermination(timeout.toSeconds, TimeUnit.SECONDS))
         _ <- F.unlessA(terminated)(F.delay(server.shutdownNow()))
       } yield (())
     }
@@ -63,14 +82,28 @@ final class ServerBuilderOps[SB <: ServerBuilder[SB]](val builder: SB) extends A
 
   /** Builds a `Server` into a stream. The server is shut down when the stream is complete. Shutdown is as follows:
     *
-    *   1. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls. 2. We
-    *      block for up to 30 seconds on termination, using the blocking context 3. If the server is not yet terminated,
-    *      we trigger a forceful shutdown
+    *   i. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls.
+    *   i. We block for up to 30 seconds on termination, using the blocking context
+    *   i. If the server is not yet terminated, we trigger a forceful shutdown
     *
-    * For different tradeoffs in shutdown behavior, see {{streamWithShutdown}}.
+    * For different tradeoffs in shutdown behavior, see [[streamWithShutdown]].
+    *
+    * @see
+    *   [[streamWithShutdownTimeout]] to explicitly set the timeout
     */
   def stream[F[_]](implicit F: Async[F]): Stream[F, Server] =
     Stream.resource(resource[F])
+
+  /** Builds a `Server` into a stream. The server is shut down when the stream is complete. Shutdown is as follows:
+    *
+    *   i. We request an orderly shutdown, allowing preexisting calls to continue without accepting new calls.
+    *   i. We block for up to {timeout} on termination, using the blocking context
+    *   i. If the server is not yet terminated, we trigger a forceful shutdown
+    *
+    * For different tradeoffs in shutdown behavior, see [[streamWithShutdown]].
+    */
+  def streamWithShutdownTimeout[F[_]](timeout: FiniteDuration)(implicit F: Sync[F]): Stream[F, Server] =
+    Stream.resource(resourceWithShutdownTimeout[F](timeout))
 
   /** Builds a `Server` into a stream. The server is shut down when the stream is complete.
     *

--- a/runtime/src/main/scala/fs2/grpc/syntax/package.scala
+++ b/runtime/src/main/scala/fs2/grpc/syntax/package.scala
@@ -24,6 +24,6 @@ package grpc
 
 package object syntax {
   object all extends AllSyntax
-  object managedChannelBuilder extends ManagedChannelBuilderSyntax
-  object serverBuilder extends ServerBuilderSyntax
+  object managedChannelBuilder extends ManagedChannelBuilderSyntax with ManagedChannelBuilderTimeoutSyntax
+  object serverBuilder extends ServerBuilderSyntax with ServerBuilderResourceTimeoutSyntax
 }


### PR DESCRIPTION
The new API is useful when an application has different graceful shutdown expectations. 