### PR TITLE
Add {Client,Service}AspectMiddleware

### DIFF
--- a/runtime/src/main/scala/fs2/grpc/client/ClientAspectMiddleware.scala
+++ b/runtime/src/main/scala/fs2/grpc/client/ClientAspectMiddleware.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.client
+
+import cats.arrow.FunctionK
+import cats.~>
+import fs2.Stream
+import io.grpc.Metadata
+
+/** A middleware for transforming effects within a [[ClientAspect]].
+  *
+  * This allows injecting custom logic (e.g., logging, metrics, error handling) around gRPC client calls without
+  * modifying the underlying client implementation.
+  *
+  * @tparam F
+  *   the effect type
+  * @tparam Ctx
+  *   the context type
+  */
+trait ClientAspectMiddleware[F[_], Ctx] {
+
+  /** Transforms unary (single response) effects.
+    *
+    * @param callCtx
+    *   the gRPC call context (method descriptor, metadata, etc.)
+    * @return
+    *   a natural transformation to apply to the effect
+    */
+  def unary[Req, Res](callCtx: ClientCallContext[Req, Res, Ctx]): F ~> F
+
+  /** Transforms streaming effects.
+    *
+    * @param callCtx
+    *   the gRPC call context (method descriptor, metadata, etc.)
+    * @return
+    *   a natural transformation to apply to the stream
+    */
+  def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, Ctx]): Stream[F, *] ~> Stream[F, *]
+
+  /** Composes this middleware with another, with `this` applied as the outer wrapper and `that` as the inner wrapper.
+    *
+    * For effects with before/after semantics, the execution order is: `this.before` -> `that.before` -> effect ->
+    * `that.after` -> `this.after`
+    */
+  def compose(that: ClientAspectMiddleware[F, Ctx]): ClientAspectMiddleware[F, Ctx] =
+    ClientAspectMiddleware.compose(this, that)
+}
+
+object ClientAspectMiddleware {
+
+  /** Creates a middleware that does nothing (identity transformation). */
+  def identity[F[_], Ctx]: ClientAspectMiddleware[F, Ctx] =
+    new ClientAspectMiddleware[F, Ctx] {
+      def unary[Req, Res](callCtx: ClientCallContext[Req, Res, Ctx]): F ~> F =
+        FunctionK.id[F]
+
+      def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, Ctx]): Stream[F, *] ~> Stream[F, *] =
+        FunctionK.id[Stream[F, *]]
+    }
+
+  /** Composes two middlewares, with `outer` applied as the outer wrapper and `inner` as the inner wrapper.
+    *
+    * For effects with before/after semantics, the execution order is: `outer.before` -> `inner.before` -> effect ->
+    * `inner.after` -> `outer.after`
+    */
+  def compose[F[_], Ctx](
+      outer: ClientAspectMiddleware[F, Ctx],
+      inner: ClientAspectMiddleware[F, Ctx]
+  ): ClientAspectMiddleware[F, Ctx] =
+    new ClientAspectMiddleware[F, Ctx] {
+      def unary[Req, Res](callCtx: ClientCallContext[Req, Res, Ctx]): F ~> F =
+        outer.unary(callCtx).compose(inner.unary(callCtx))
+
+      def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, Ctx]): Stream[F, *] ~> Stream[F, *] =
+        outer.streaming(callCtx).compose(inner.streaming(callCtx))
+    }
+
+  /** Composes multiple middlewares into one, with earlier middlewares as outer wrappers and later middlewares as inner
+    * wrappers.
+    *
+    * For effects with before/after semantics, the execution order is: `first.before` -> `second.before` -> ... ->
+    * effect -> ... -> `second.after` -> `first.after`
+    */
+  def composeAll[F[_], Ctx](middlewares: ClientAspectMiddleware[F, Ctx]*): ClientAspectMiddleware[F, Ctx] =
+    middlewares.foldLeft(identity[F, Ctx])(_.compose(_))
+
+  /** Wraps the client aspect with custom effect transformations.
+    *
+    * @param middleware
+    *   the middleware providing the transformations
+    * @param aspect
+    *   the client aspect to wrap
+    * @return
+    *   a new client aspect with the middleware applied
+    */
+  def wrap[F[_], G[_], A](
+      middleware: ClientAspectMiddleware[G, A],
+      aspect: ClientAspect[F, G, A]
+  ): ClientAspect[F, G, A] =
+    new WrappedClientAspect(middleware, aspect)
+
+  implicit class ClientAspectMiddlewareOps[F[_], G[_], Ctx](private val self: ClientAspect[F, G, Ctx]) extends AnyVal {
+
+    /** Wraps the client aspect with custom effect transformations.
+      *
+      * @param middleware
+      *   the middleware providing the transformations
+      * @return
+      *   a new client aspect with the middleware applied
+      */
+    def wrap(middleware: ClientAspectMiddleware[G, Ctx]): ClientAspect[F, G, Ctx] =
+      ClientAspectMiddleware.wrap(middleware, self)
+
+    /** Wraps the client aspect with multiple middlewares, with earlier middlewares as outer wrappers and later
+      * middlewares as inner wrappers.
+      */
+    def wrapAll(middlewares: ClientAspectMiddleware[G, Ctx]*): ClientAspect[F, G, Ctx] =
+      wrap(composeAll(middlewares: _*))
+  }
+
+  final private class WrappedClientAspect[F[_], G[_], Ctx](
+      middleware: ClientAspectMiddleware[G, Ctx],
+      inner: ClientAspect[F, G, Ctx]
+  ) extends ClientAspect[F, G, Ctx] {
+
+    def visitUnaryToUnaryCall[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Ctx],
+        req: Req,
+        run: (Req, Metadata) => G[Res]
+    ): F[Res] =
+      inner.visitUnaryToUnaryCall(callCtx, req, (r: Req, meta: Metadata) => middleware.unary(callCtx)(run(r, meta)))
+
+    def visitUnaryToStreamingCall[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Ctx],
+        req: Req,
+        run: (Req, Metadata) => Stream[G, Res]
+    ): Stream[F, Res] =
+      inner.visitUnaryToStreamingCall(
+        callCtx,
+        req,
+        (r: Req, meta: Metadata) => middleware.streaming(callCtx)(run(r, meta))
+      )
+
+    def visitStreamingToUnaryCall[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Ctx],
+        req: Stream[F, Req],
+        run: (Stream[G, Req], Metadata) => G[Res]
+    ): F[Res] =
+      inner.visitStreamingToUnaryCall(
+        callCtx,
+        req,
+        (r: Stream[G, Req], meta: Metadata) => middleware.unary(callCtx)(run(r, meta))
+      )
+
+    def visitStreamingToStreamingCall[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Ctx],
+        req: Stream[F, Req],
+        run: (Stream[G, Req], Metadata) => Stream[G, Res]
+    ): Stream[F, Res] =
+      inner.visitStreamingToStreamingCall(
+        callCtx,
+        req,
+        (r: Stream[G, Req], meta: Metadata) => middleware.streaming(callCtx)(run(r, meta))
+      )
+
+    def visitUnaryToUnaryCallTrailers[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Ctx],
+        req: Req,
+        run: (Req, Metadata) => G[(Res, Metadata)]
+    ): F[(Res, Metadata)] =
+      inner.visitUnaryToUnaryCallTrailers(
+        callCtx,
+        req,
+        (r: Req, meta: Metadata) => middleware.unary(callCtx)(run(r, meta))
+      )
+
+    def visitStreamingToUnaryCallTrailers[Req, Res](
+        callCtx: ClientCallContext[Req, Res, Ctx],
+        req: Stream[F, Req],
+        run: (Stream[G, Req], Metadata) => G[(Res, Metadata)]
+    ): F[(Res, Metadata)] =
+      inner.visitStreamingToUnaryCallTrailers(
+        callCtx,
+        req,
+        (r: Stream[G, Req], meta: Metadata) => middleware.unary(callCtx)(run(r, meta))
+      )
+  }
+}

--- a/runtime/src/main/scala/fs2/grpc/server/ServiceAspectMiddleware.scala
+++ b/runtime/src/main/scala/fs2/grpc/server/ServiceAspectMiddleware.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.server
+
+import cats.arrow.FunctionK
+import cats.~>
+import fs2.Stream
+import io.grpc.Metadata
+
+/** A middleware for transforming effects within a [[ServiceAspect]].
+  *
+  * This allows injecting custom logic (e.g., logging, metrics, error handling) around gRPC service calls without
+  * modifying the underlying service implementation.
+  *
+  * @tparam F
+  *   the effect type
+  * @tparam Ctx
+  *   the context type
+  */
+trait ServiceAspectMiddleware[F[_], Ctx] {
+
+  /** Transforms unary (single response) effects.
+    *
+    * @param callCtx
+    *   the gRPC call context (method descriptor, metadata, etc.)
+    * @param ctx
+    *   the user context for the current call
+    * @return
+    *   a natural transformation to apply to the effect
+    */
+  def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Ctx): F ~> F
+
+  /** Transforms streaming effects.
+    *
+    * @param callCtx
+    *   the gRPC call context (method descriptor, metadata, etc.)
+    * @param ctx
+    *   the user context for the current call
+    * @return
+    *   a natural transformation to apply to the stream
+    */
+  def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Ctx): Stream[F, *] ~> Stream[F, *]
+
+  /** Composes this middleware with another, with `this` applied as the outer wrapper and `that` as the inner wrapper.
+    *
+    * For effects with before/after semantics, the execution order is: `this.before` -> `that.before` -> effect ->
+    * `that.after` -> `this.after`
+    */
+  def compose(that: ServiceAspectMiddleware[F, Ctx]): ServiceAspectMiddleware[F, Ctx] =
+    ServiceAspectMiddleware.compose(this, that)
+}
+
+object ServiceAspectMiddleware {
+
+  /** Creates a middleware that does nothing (identity transformation). */
+  def identity[F[_], Ctx]: ServiceAspectMiddleware[F, Ctx] =
+    new ServiceAspectMiddleware[F, Ctx] {
+      def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Ctx): F ~> F =
+        FunctionK.id[F]
+
+      def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Ctx): Stream[F, *] ~> Stream[F, *] =
+        FunctionK.id[Stream[F, *]]
+    }
+
+  /** Composes two middlewares, with `outer` applied as the outer wrapper and `inner` as the inner wrapper.
+    *
+    * For effects with before/after semantics, the execution order is: `outer.before` -> `inner.before` -> effect ->
+    * `inner.after` -> `outer.after`
+    */
+  def compose[F[_], Ctx](
+      outer: ServiceAspectMiddleware[F, Ctx],
+      inner: ServiceAspectMiddleware[F, Ctx]
+  ): ServiceAspectMiddleware[F, Ctx] =
+    new ServiceAspectMiddleware[F, Ctx] {
+      def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Ctx): F ~> F =
+        outer.unary(callCtx, ctx).compose(inner.unary(callCtx, ctx))
+
+      def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Ctx): Stream[F, *] ~> Stream[F, *] =
+        outer.streaming(callCtx, ctx).compose(inner.streaming(callCtx, ctx))
+    }
+
+  /** Composes multiple middlewares into one, with earlier middlewares as outer wrappers and later middlewares as inner
+    * wrappers.
+    *
+    * For effects with before/after semantics, the execution order is: `first.before` -> `second.before` -> ... ->
+    * effect -> ... -> `second.after` -> `first.after`
+    */
+  def composeAll[F[_], Ctx](middlewares: ServiceAspectMiddleware[F, Ctx]*): ServiceAspectMiddleware[F, Ctx] =
+    middlewares.foldLeft(identity[F, Ctx])(_.compose(_))
+
+  /** Wraps the service aspect with custom effect transformations.
+    *
+    * @param middleware
+    *   the middleware providing the transformations
+    * @param aspect
+    *   the service aspect to wrap
+    * @return
+    *   a new service aspect with the middleware applied
+    */
+  def wrap[F[_], G[_], A](
+      middleware: ServiceAspectMiddleware[F, A],
+      aspect: ServiceAspect[F, G, A]
+  ): ServiceAspect[F, G, A] =
+    new WrappedServiceAspect(middleware, aspect)
+
+  implicit class ServiceAspectMiddlewareOps[F[_], G[_], Ctx](private val self: ServiceAspect[F, G, Ctx])
+      extends AnyVal {
+
+    /** Wraps the service aspect with custom effect transformations.
+      *
+      * @param middleware
+      *   the middleware providing the transformations
+      * @return
+      *   a new service aspect with the middleware applied
+      */
+    def wrap(middleware: ServiceAspectMiddleware[F, Ctx]): ServiceAspect[F, G, Ctx] =
+      ServiceAspectMiddleware.wrap(middleware, self)
+
+    /** Wraps the service aspect with multiple middlewares, with earlier middlewares as outer wrappers and later
+      * middlewares as inner wrappers.
+      */
+    def wrapAll(middlewares: ServiceAspectMiddleware[F, Ctx]*): ServiceAspect[F, G, Ctx] =
+      wrap(composeAll(middlewares: _*))
+  }
+
+  final private class WrappedServiceAspect[F[_], G[_], Ctx](
+      middleware: ServiceAspectMiddleware[F, Ctx],
+      inner: ServiceAspect[F, G, Ctx]
+  ) extends ServiceAspect[F, G, Ctx] {
+
+    def visitUnaryToUnaryCall[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Req,
+        run: (Req, Ctx) => F[Res]
+    ): G[Res] =
+      inner.visitUnaryToUnaryCall(callCtx, req, (r: Req, a: Ctx) => middleware.unary(callCtx, a)(run(r, a)))
+
+    def visitUnaryToStreamingCall[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Req,
+        run: (Req, Ctx) => Stream[F, Res]
+    ): Stream[G, Res] =
+      inner.visitUnaryToStreamingCall(
+        callCtx,
+        req,
+        (r: Req, a: Ctx) => middleware.streaming(callCtx, a)(run(r, a))
+      )
+
+    def visitStreamingToUnaryCall[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Stream[G, Req],
+        run: (Stream[F, Req], Ctx) => F[Res]
+    ): G[Res] =
+      inner.visitStreamingToUnaryCall(
+        callCtx,
+        req,
+        (r: Stream[F, Req], a: Ctx) => middleware.unary(callCtx, a)(run(r, a))
+      )
+
+    def visitStreamingToStreamingCall[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Stream[G, Req],
+        run: (Stream[F, Req], Ctx) => Stream[F, Res]
+    ): Stream[G, Res] =
+      inner.visitStreamingToStreamingCall(
+        callCtx,
+        req,
+        (r: Stream[F, Req], a: Ctx) => middleware.streaming(callCtx, a)(run(r, a))
+      )
+
+    def visitUnaryToUnaryCallTrailers[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Req,
+        run: (Req, Ctx) => F[(Res, Metadata)]
+    ): G[(Res, Metadata)] =
+      inner.visitUnaryToUnaryCallTrailers(
+        callCtx,
+        req,
+        (r: Req, a: Ctx) => middleware.unary(callCtx, a)(run(r, a))
+      )
+
+    def visitStreamingToUnaryCallTrailers[Req, Res](
+        callCtx: ServiceCallContext[Req, Res],
+        req: Stream[G, Req],
+        run: (Stream[F, Req], Ctx) => F[(Res, Metadata)]
+    ): G[(Res, Metadata)] =
+      inner.visitStreamingToUnaryCallTrailers(
+        callCtx,
+        req,
+        (r: Stream[F, Req], a: Ctx) => middleware.unary(callCtx, a)(run(r, a))
+      )
+  }
+}

--- a/runtime/src/test/scala/fs2/grpc/client/ClientAspectMiddlewareSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/client/ClientAspectMiddlewareSuite.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.client
+
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.~>
+import fs2.Stream
+import io.grpc.{Metadata, MethodDescriptor}
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.collection.mutable.ListBuffer
+
+class ClientAspectMiddlewareSuite extends munit.CatsEffectSuite {
+
+  import ClientAspectMiddleware._
+
+  test("compose should apply outer middleware's error handler after inner's on error") {
+    val events = ListBuffer.empty[String]
+
+    val outer = new ClientAspectMiddleware[IO, Unit] {
+      def unary[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            fa.onError { case _ => IO(events += "outer-error").void }
+        }
+
+      def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): Stream[IO, *] ~> Stream[IO, *] =
+        FunctionK.id
+    }
+
+    val inner = new ClientAspectMiddleware[IO, Unit] {
+      def unary[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            fa.onError { case _ => IO(events += "inner-error").void }
+        }
+
+      def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): Stream[IO, *] ~> Stream[IO, *] =
+        FunctionK.id
+    }
+
+    val composed = outer.compose(inner)
+    val callCtx = mockClientCallContext(())
+
+    composed
+      .unary(callCtx)(IO.raiseError[Int](new RuntimeException("test error")))
+      .attempt
+      .map(r => assertEquals(r.isLeft, true)) *> IO(assertEquals(events.toList, List("inner-error", "outer-error")))
+  }
+
+  test("identity should not modify effects") {
+    val middleware = ClientAspectMiddleware.identity[IO, Unit]
+    val callCtx = mockClientCallContext(())
+
+    middleware.unary(callCtx)(IO.pure(42)).map(r => assertEquals(r, 42))
+  }
+
+  test("identity should not modify streams") {
+    val middleware = ClientAspectMiddleware.identity[IO, Unit]
+    val callCtx = mockClientCallContext(())
+
+    middleware.streaming(callCtx)(Stream(1, 2, 3)).compile.toList.map(r => assertEquals(r, List(1, 2, 3)))
+  }
+
+  test("compose should run middlewares in order") {
+    val events = ListBuffer.empty[String]
+
+    val first = new ClientAspectMiddleware[IO, Unit] {
+      def unary[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            IO(events += "first-before") *> fa <* IO(events += "first-after")
+        }
+
+      def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): Stream[IO, *] ~> Stream[IO, *] =
+        new (Stream[IO, *] ~> Stream[IO, *]) {
+          def apply[A](s: Stream[IO, A]): Stream[IO, A] =
+            Stream
+              .eval(IO(events += "first-stream-before")) >> s ++ Stream.eval(IO(events += "first-stream-after")).drain
+        }
+    }
+
+    val second = new ClientAspectMiddleware[IO, Unit] {
+      def unary[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            IO(events += "second-before") *> fa <* IO(events += "second-after")
+        }
+
+      def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): Stream[IO, *] ~> Stream[IO, *] =
+        new (Stream[IO, *] ~> Stream[IO, *]) {
+          def apply[A](s: Stream[IO, A]): Stream[IO, A] =
+            Stream.eval(IO(events += "second-stream-before")) >> s ++ Stream
+              .eval(IO(events += "second-stream-after"))
+              .drain
+        }
+    }
+
+    val composed = first.compose(second)
+    val callCtx = mockClientCallContext(())
+
+    composed.unary(callCtx)(IO.pure(42)).map { r =>
+      assertEquals(r, 42)
+      assertEquals(events.toList, List("first-before", "second-before", "second-after", "first-after"))
+    }
+  }
+
+  test("composeAll should combine multiple middlewares") {
+    val counter = new AtomicReference(0)
+
+    def countingMiddleware(n: Int): ClientAspectMiddleware[IO, Unit] =
+      new ClientAspectMiddleware[IO, Unit] {
+        def unary[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): IO ~> IO =
+          new (IO ~> IO) {
+            def apply[A](fa: IO[A]): IO[A] =
+              IO(counter.updateAndGet(_ + n)) *> fa
+          }
+
+        def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, Unit]): Stream[IO, *] ~> Stream[IO, *] =
+          new (Stream[IO, *] ~> Stream[IO, *]) {
+            def apply[A](s: Stream[IO, A]): Stream[IO, A] =
+              Stream.eval(IO(counter.updateAndGet(_ + n))) >> s
+          }
+      }
+
+    val combined = ClientAspectMiddleware.composeAll(
+      countingMiddleware(1),
+      countingMiddleware(10),
+      countingMiddleware(100)
+    )
+    val callCtx = mockClientCallContext(())
+
+    combined.unary(callCtx)(IO.pure("done")).map { r =>
+      assertEquals(r, "done")
+      assertEquals(counter.get(), 111)
+    }
+  }
+
+  test("wrap extension should wrap ClientAspect") {
+    val events = ListBuffer.empty[String]
+
+    val baseAspect = new ClientAspect[IO, IO, String] {
+      def visitUnaryToUnaryCall[Req, Res](
+          callCtx: ClientCallContext[Req, Res, String],
+          req: Req,
+          run: (Req, Metadata) => IO[Res]
+      ): IO[Res] = {
+        events += "aspect-before"
+        run(req, new Metadata()) <* IO(events += "aspect-after")
+      }
+
+      def visitUnaryToStreamingCall[Req, Res](
+          callCtx: ClientCallContext[Req, Res, String],
+          req: Req,
+          run: (Req, Metadata) => Stream[IO, Res]
+      ): Stream[IO, Res] =
+        Stream.eval(IO(events += "aspect-stream")) >> run(req, new Metadata())
+
+      def visitStreamingToUnaryCall[Req, Res](
+          callCtx: ClientCallContext[Req, Res, String],
+          req: Stream[IO, Req],
+          run: (Stream[IO, Req], Metadata) => IO[Res]
+      ): IO[Res] = run(req, new Metadata())
+
+      def visitStreamingToStreamingCall[Req, Res](
+          callCtx: ClientCallContext[Req, Res, String],
+          req: Stream[IO, Req],
+          run: (Stream[IO, Req], Metadata) => Stream[IO, Res]
+      ): Stream[IO, Res] = run(req, new Metadata())
+
+      def visitUnaryToUnaryCallTrailers[Req, Res](
+          callCtx: ClientCallContext[Req, Res, String],
+          req: Req,
+          run: (Req, Metadata) => IO[(Res, Metadata)]
+      ): IO[(Res, Metadata)] = run(req, new Metadata())
+
+      def visitStreamingToUnaryCallTrailers[Req, Res](
+          callCtx: ClientCallContext[Req, Res, String],
+          req: Stream[IO, Req],
+          run: (Stream[IO, Req], Metadata) => IO[(Res, Metadata)]
+      ): IO[(Res, Metadata)] = run(req, new Metadata())
+    }
+
+    val middleware = new ClientAspectMiddleware[IO, String] {
+      def unary[Req, Res](callCtx: ClientCallContext[Req, Res, String]): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            IO(events += s"middleware-before-${callCtx.ctx}") *> fa <* IO(
+              events += s"middleware-after-${callCtx.ctx}"
+            )
+        }
+
+      def streaming[Req, Res](callCtx: ClientCallContext[Req, Res, String]): Stream[IO, *] ~> Stream[IO, *] =
+        new (Stream[IO, *] ~> Stream[IO, *]) {
+          def apply[A](s: Stream[IO, A]): Stream[IO, A] =
+            Stream.eval(IO(events += s"middleware-stream-${callCtx.ctx}")) >> s
+        }
+    }
+
+    val wrappedAspect = baseAspect.wrap(middleware)
+    val callCtx = mockClientCallContext("context")
+
+    wrappedAspect
+      .visitUnaryToUnaryCall(callCtx, "request", (_: Any, _: Metadata) => IO.pure("response"))
+      .map { r =>
+        assertEquals(r, "response")
+        assertEquals(
+          events.toList,
+          List("aspect-before", "middleware-before-context", "middleware-after-context", "aspect-after")
+        )
+      }
+  }
+
+  private def mockClientCallContext[A](ctx: A): ClientCallContext[Any, Any, A] =
+    ClientCallContext(
+      methodDescriptor = MethodDescriptor
+        .newBuilder()
+        .setType(MethodDescriptor.MethodType.UNARY)
+        .setFullMethodName("test/method")
+        .setRequestMarshaller(new NoopMarshaller)
+        .setResponseMarshaller(new NoopMarshaller)
+        .build(),
+      ctx = ctx
+    )
+
+  private class NoopMarshaller extends io.grpc.MethodDescriptor.Marshaller[Any] {
+    def stream(value: Any): java.io.InputStream = null
+    def parse(stream: java.io.InputStream): Any = null
+  }
+}

--- a/runtime/src/test/scala/fs2/grpc/server/ServiceAspectMiddlewareSuite.scala
+++ b/runtime/src/test/scala/fs2/grpc/server/ServiceAspectMiddlewareSuite.scala
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2018 Gary Coady / Fs2 Grpc Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package fs2.grpc.server
+
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.~>
+import fs2.Stream
+import io.grpc.{Metadata, MethodDescriptor}
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.collection.mutable.ListBuffer
+
+class ServiceAspectMiddlewareSuite extends munit.CatsEffectSuite {
+
+  import ServiceAspectMiddleware._
+
+  test("compose should apply outer middleware's error handler after inner's on error") {
+    val events = ListBuffer.empty[String]
+
+    val outer = new ServiceAspectMiddleware[IO, Unit] {
+      def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            fa.onError { case _ => IO(events += "outer-error").void }
+        }
+
+      def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): Stream[IO, *] ~> Stream[IO, *] =
+        FunctionK.id
+    }
+
+    val inner = new ServiceAspectMiddleware[IO, Unit] {
+      def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            fa.onError { case _ => IO(events += "inner-error").void }
+        }
+
+      def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): Stream[IO, *] ~> Stream[IO, *] =
+        FunctionK.id
+    }
+
+    val composed = outer.compose(inner)
+    val callCtx = mockServiceCallContext()
+
+    composed
+      .unary(callCtx, ())(IO.raiseError[Int](new RuntimeException("test error")))
+      .attempt
+      .map(r => assertEquals(r.isLeft, true)) *> IO(assertEquals(events.toList, List("inner-error", "outer-error")))
+  }
+
+  test("identity should not modify effects") {
+    val middleware = ServiceAspectMiddleware.identity[IO, Unit]
+    val callCtx = mockServiceCallContext()
+
+    middleware.unary(callCtx, ())(IO.pure(42)).map(r => assertEquals(r, 42))
+  }
+
+  test("identity should not modify streams") {
+    val middleware = ServiceAspectMiddleware.identity[IO, Unit]
+    val callCtx = mockServiceCallContext()
+
+    middleware.streaming(callCtx, ())(Stream(1, 2, 3)).compile.toList.map(r => assertEquals(r, List(1, 2, 3)))
+  }
+
+  test("compose should run middlewares in order") {
+    val events = ListBuffer.empty[String]
+
+    val first = new ServiceAspectMiddleware[IO, Unit] {
+      def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            IO(events += "first-before") *> fa <* IO(events += "first-after")
+        }
+
+      def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): Stream[IO, *] ~> Stream[IO, *] =
+        new (Stream[IO, *] ~> Stream[IO, *]) {
+          def apply[A](s: Stream[IO, A]): Stream[IO, A] =
+            Stream
+              .eval(IO(events += "first-stream-before")) >> s ++ Stream.eval(IO(events += "first-stream-after")).drain
+        }
+    }
+
+    val second = new ServiceAspectMiddleware[IO, Unit] {
+      def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            IO(events += "second-before") *> fa <* IO(events += "second-after")
+        }
+
+      def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): Stream[IO, *] ~> Stream[IO, *] =
+        new (Stream[IO, *] ~> Stream[IO, *]) {
+          def apply[A](s: Stream[IO, A]): Stream[IO, A] =
+            Stream.eval(IO(events += "second-stream-before")) >> s ++ Stream
+              .eval(IO(events += "second-stream-after"))
+              .drain
+        }
+    }
+
+    val composed = first.compose(second)
+    val callCtx = mockServiceCallContext()
+
+    composed.unary(callCtx, ())(IO.pure(42)).map { r =>
+      assertEquals(r, 42)
+      assertEquals(events.toList, List("first-before", "second-before", "second-after", "first-after"))
+    }
+  }
+
+  test("composeAll should combine multiple middlewares") {
+    val counter = new AtomicReference(0)
+
+    def countingMiddleware(n: Int): ServiceAspectMiddleware[IO, Unit] =
+      new ServiceAspectMiddleware[IO, Unit] {
+        def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): IO ~> IO =
+          new (IO ~> IO) {
+            def apply[A](fa: IO[A]): IO[A] =
+              IO(counter.updateAndGet(_ + n)) *> fa
+          }
+
+        def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: Unit): Stream[IO, *] ~> Stream[IO, *] =
+          new (Stream[IO, *] ~> Stream[IO, *]) {
+            def apply[A](s: Stream[IO, A]): Stream[IO, A] =
+              Stream.eval(IO(counter.updateAndGet(_ + n))) >> s
+          }
+      }
+
+    val combined = ServiceAspectMiddleware.composeAll(
+      countingMiddleware(1),
+      countingMiddleware(10),
+      countingMiddleware(100)
+    )
+    val callCtx = mockServiceCallContext()
+
+    combined.unary(callCtx, ())(IO.pure("done")).map { r =>
+      assertEquals(r, "done")
+      assertEquals(counter.get(), 111)
+    }
+  }
+
+  test("wrap extension should wrap ServiceAspect") {
+    val events = ListBuffer.empty[String]
+
+    val baseAspect = new ServiceAspect[IO, IO, String] {
+      def visitUnaryToUnaryCall[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Req,
+          run: (Req, String) => IO[Res]
+      ): IO[Res] = {
+        events += "aspect-before"
+        run(req, "context") <* IO(events += "aspect-after")
+      }
+
+      def visitUnaryToStreamingCall[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Req,
+          run: (Req, String) => Stream[IO, Res]
+      ): Stream[IO, Res] =
+        Stream.eval(IO(events += "aspect-stream")) >> run(req, "context")
+
+      def visitStreamingToUnaryCall[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Stream[IO, Req],
+          run: (Stream[IO, Req], String) => IO[Res]
+      ): IO[Res] = run(req, "context")
+
+      def visitStreamingToStreamingCall[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Stream[IO, Req],
+          run: (Stream[IO, Req], String) => Stream[IO, Res]
+      ): Stream[IO, Res] = run(req, "context")
+
+      def visitUnaryToUnaryCallTrailers[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Req,
+          run: (Req, String) => IO[(Res, Metadata)]
+      ): IO[(Res, Metadata)] = run(req, "context")
+
+      def visitStreamingToUnaryCallTrailers[Req, Res](
+          callCtx: ServiceCallContext[Req, Res],
+          req: Stream[IO, Req],
+          run: (Stream[IO, Req], String) => IO[(Res, Metadata)]
+      ): IO[(Res, Metadata)] = run(req, "context")
+    }
+
+    val middleware = new ServiceAspectMiddleware[IO, String] {
+      def unary[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: String): IO ~> IO =
+        new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] =
+            IO(events += s"middleware-before-$ctx") *> fa <* IO(events += s"middleware-after-$ctx")
+        }
+
+      def streaming[Req, Res](callCtx: ServiceCallContext[Req, Res], ctx: String): Stream[IO, *] ~> Stream[IO, *] =
+        new (Stream[IO, *] ~> Stream[IO, *]) {
+          def apply[A](s: Stream[IO, A]): Stream[IO, A] =
+            Stream.eval(IO(events += s"middleware-stream-$ctx")) >> s
+        }
+    }
+
+    val wrappedAspect = baseAspect.wrap(middleware)
+    val callCtx = mockServiceCallContext()
+
+    wrappedAspect
+      .visitUnaryToUnaryCall(callCtx, "request", (_: Any, ctx: String) => IO.pure(s"response-$ctx"))
+      .map { r =>
+        assertEquals(r, "response-context")
+        assertEquals(
+          events.toList,
+          List("aspect-before", "middleware-before-context", "middleware-after-context", "aspect-after")
+        )
+      }
+  }
+
+  private def mockServiceCallContext(): ServiceCallContext[Any, Any] =
+    ServiceCallContext(
+      methodDescriptor = MethodDescriptor
+        .newBuilder()
+        .setType(MethodDescriptor.MethodType.UNARY)
+        .setFullMethodName("test/method")
+        .setRequestMarshaller(new NoopMarshaller)
+        .setResponseMarshaller(new NoopMarshaller)
+        .build(),
+      metadata = new Metadata()
+    )
+
+  private class NoopMarshaller extends io.grpc.MethodDescriptor.Marshaller[Any] {
+    def stream(value: Any): java.io.InputStream = null
+    def parse(stream: java.io.InputStream): Any = null
+  }
+}


### PR DESCRIPTION
## Motivation

`ClientAspect[F, G, A]` and `ServiceAspect[F, G, A]` have six `visitX` methods covering every combination of unary/streaming and trailing-metadata variants. Implementing or composing an aspect for a cross-cutting concern (logging, metrics, error handling, timing) currently requires implementing all six methods even when the only thing that varies is "wrap the effect that runs the call". There's also no built-in way to combine multiple such concerns into a single aspect.

This PR adds a thin abstraction that captures that common case in two methods (`unary`, streaming`) and a `wrap operator that lifts the middleware over an existing aspect. It complements the existing `contraModify`/`modify` context-transformation methods rather than replacing them.

## Composition semantics

`a.compose(b)` runs `a` as the outer wrapper and `b` as the inner one. For effects with before/after semantics:
`a.before -> b.before -> effect -> b.after -> a.after`
On error: inner error handlers fire before outer ones. This matches what `FunctionK.compose` does (`a.compose(b)(x) = a(b(x))`) and is asserted in the tests.

## Why "Middleware" / "wrap" (naming)

- "Interceptor" would have collided with `io.grpc.ClientInterceptor` / `io.grpc.ServerInterceptor`, which are an unrelated lower-level concept; "Middleware" is the standard FP-ecosystem term for this pattern and unambiguous.
- The companion operator is wrap (and `wrapAll`) to keep the verb consistent with the noun.
